### PR TITLE
Patch Dancer Ability

### DIFF
--- a/Data/Scripts/011_Battle/001_Battler/007_Battler_UseMove.rb
+++ b/Data/Scripts/011_Battle/001_Battler/007_Battler_UseMove.rb
@@ -534,7 +534,8 @@ class PokeBattle_Battler
     end
     # Dancer
     if !@effects[PBEffects::Dancer] && !user.lastMoveFailed && realNumHits>0 &&
-       !move.snatched && magicCoater<0 && @battle.pbCheckGlobalAbility(:DANCER)
+       !move.snatched && magicCoater<0 && @battle.pbCheckGlobalAbility(:DANCER) &&
+       move.danceMove?
       dancers = []
       @battle.pbPriority(true).each do |b|
         dancers.push(b) if b.index!=user.index && b.hasActiveAbility?(:DANCER)


### PR DESCRIPTION
This makes dancer work only if a Pokémon uses a dance move (Such as Swords Dance), not when using whichever move. Tested on my copy of V18 and worked