### PR TITLE
Check for Pokémon species with #isSpecies? instead of Object.isConst?

### DIFF
--- a/Data/Scripts/012_Battle/001_Battler/001_PokeBattle_Battler.rb
+++ b/Data/Scripts/012_Battle/001_Battler/001_PokeBattle_Battler.rb
@@ -271,6 +271,10 @@ class PokeBattle_Battler
     return ret
   end
 
+  def isSpecies?(species)
+    return @pokemon && @pokemon.isSpecies?(species)
+  end
+
   # Returns the active types of this Pokémon. The array should not include the
   # same type more than once, and should not include any invalid type numbers
   # (e.g. -1).

--- a/Data/Scripts/012_Battle/001_Battler/002_Battler_Initialize.rb
+++ b/Data/Scripts/012_Battle/001_Battler/002_Battler_Initialize.rb
@@ -108,7 +108,7 @@ class PokeBattle_Battler
       end
       # These effects are passed on if Baton Pass is used, but they need to be
       # cancelled in certain circumstances anyway
-      @effects[PBEffects::Telekinesis] = 0 if isConst?(@species,PBSpecies,:GENGAR) && mega?
+      @effects[PBEffects::Telekinesis] = 0 if isSpecies?(:GENGAR) && mega?
       @effects[PBEffects::GastroAcid]  = false if nonNegatableAbility?
     else
       # These effects are passed on if Baton Pass is used

--- a/Data/Scripts/012_Battle/001_Battler/003_Battler_ChangeSelf.rb
+++ b/Data/Scripts/012_Battle/001_Battler/003_Battler_ChangeSelf.rb
@@ -149,7 +149,7 @@ class PokeBattle_Battler
   def pbCheckFormOnStatusChange
     return if fainted? || @effects[PBEffects::Transform]
     # Shaymin - reverts if frozen
-    if isConst?(@species,PBSpecies,:SHAYMIN) && frozen?
+    if isSpecies?(:SHAYMIN) && frozen?
       pbChangeForm(0,_INTL("{1} transformed!",pbThis))
     end
   end
@@ -157,7 +157,7 @@ class PokeBattle_Battler
   def pbCheckFormOnMovesetChange
     return if fainted? || @effects[PBEffects::Transform]
     # Keldeo - knowing Secret Sword
-    if isConst?(@species,PBSpecies,:KELDEO)
+    if isSpecies?(:KELDEO)
       newForm = 0
       newForm = 1 if pbHasMove?(:SECRETSWORD)
       pbChangeForm(newForm,_INTL("{1} transformed!",pbThis))
@@ -167,7 +167,7 @@ class PokeBattle_Battler
   def pbCheckFormOnWeatherChange
     return if fainted? || @effects[PBEffects::Transform]
     # Castform - Forecast
-    if isConst?(@species,PBSpecies,:CASTFORM)
+    if isSpecies?(:CASTFORM)
       if hasActiveAbility?(:FORECAST)
         newForm = 0
         case @battle.pbWeather
@@ -185,7 +185,7 @@ class PokeBattle_Battler
       end
     end
     # Cherrim - Flower Gift
-    if isConst?(@species,PBSpecies,:CHERRIM)
+    if isSpecies?(:CHERRIM)
       if hasActiveAbility?(:FLOWERGIFT)
         newForm = 0
         case @battle.pbWeather
@@ -210,7 +210,7 @@ class PokeBattle_Battler
     # Form changes upon entering battle and when the weather changes
     pbCheckFormOnWeatherChange if !endOfRound
     # Darmanitan - Zen Mode
-    if isConst?(@species,PBSpecies,:DARMANITAN) && isConst?(@ability,PBAbilities,:ZENMODE)
+    if isSpecies?(:DARMANITAN) && isConst?(@ability,PBAbilities,:ZENMODE)
       if @hp<=@totalhp/2
         if @form!=1
           @battle.pbShowAbilitySplash(self,true)
@@ -224,7 +224,7 @@ class PokeBattle_Battler
       end
     end
     # Minior - Shields Down
-    if isConst?(@species,PBSpecies,:MINIOR) && isConst?(@ability,PBAbilities,:SHIELDSDOWN)
+    if isSpecies?(:MINIOR) && isConst?(@ability,PBAbilities,:SHIELDSDOWN)
       if @hp>@totalhp/2   # Turn into Meteor form
         newForm = (@form>=7) ? @form-7 : @form
         if @form!=newForm
@@ -241,7 +241,7 @@ class PokeBattle_Battler
       end
     end
     # Wishiwashi - Schooling
-    if isConst?(@species,PBSpecies,:WISHIWASHI) && isConst?(@ability,PBAbilities,:SCHOOLING)
+    if isSpecies?(:WISHIWASHI) && isConst?(@ability,PBAbilities,:SCHOOLING)
       if @level>=20 && @hp>@totalhp/4
         if @form!=1
           @battle.pbShowAbilitySplash(self,true)
@@ -255,7 +255,7 @@ class PokeBattle_Battler
       end
     end
     # Zygarde - Power Construct
-    if isConst?(@species,PBSpecies,:ZYGARDE) && isConst?(@ability,PBAbilities,:POWERCONSTRUCT) &&
+    if isSpecies?(:ZYGARDE) && isConst?(@ability,PBAbilities,:POWERCONSTRUCT) &&
        endOfRound
       if @hp<=@totalhp/2 && @form<2   # Turn into Complete Forme
         newForm = @form+2

--- a/Data/Scripts/012_Battle/001_Battler/007_Battler_UseMove.rb
+++ b/Data/Scripts/012_Battle/001_Battler/007_Battler_UseMove.rb
@@ -216,7 +216,7 @@ class PokeBattle_Battler
       end
     end
     # Stance Change
-    if isConst?(@species,PBSpecies,:AEGISLASH) && isConst?(@ability,PBAbilities,:STANCECHANGE)
+    if isSpecies?(:AEGISLASH) && isConst?(@ability,PBAbilities,:STANCECHANGE)
       if move.damagingMove?
         pbChangeForm(1,_INTL("{1} changed to Blade Forme!",pbThis))
       elsif isConst?(move.id,PBMoves,:KINGSSHIELD)

--- a/Data/Scripts/012_Battle/001_Battler/010_Battler_UseMove_TriggerEffects.rb
+++ b/Data/Scripts/012_Battle/001_Battler/010_Battler_UseMove_TriggerEffects.rb
@@ -96,7 +96,7 @@ class PokeBattle_Battler
     end
     # Greninja - Battle Bond
     if !user.fainted? && !user.effects[PBEffects::Transform] &&
-       isConst?(user.species,PBSpecies,:GRENINJA) &&
+       user.isSpecies?(:GRENINJA) &&
        isConst?(user.ability,PBAbilities,:BATTLEBOND)
       if !@battle.pbAllFainted?(user.idxOpposingSide) &&
          !@battle.battleBond[user.index&1][user.pokemonIndex]

--- a/Data/Scripts/012_Battle/002_Move/005_Move_Effects_000-07F.rb
+++ b/Data/Scripts/012_Battle/002_Move/005_Move_Effects_000-07F.rb
@@ -33,7 +33,7 @@ end
 class PokeBattle_Move_003 < PokeBattle_SleepMove
   def pbMoveFailed?(user,targets)
     if NEWEST_BATTLE_MECHANICS && isConst?(@id,PBMoves,:DARKVOID)
-      if !isConst?(user.species,PBSpecies,:DARKRAI) &&
+      if !user.isSpecies?(:DARKRAI) &&
          !isConst?(user.effects[PBEffects::TransformSpecies],PBSpecies,:DARKRAI)
         @battle.pbDisplay(_INTL("But {1} can't use the move!",user.pbThis))
         return true
@@ -46,7 +46,7 @@ class PokeBattle_Move_003 < PokeBattle_SleepMove
     return if numHits==0
     return if user.fainted? || user.effects[PBEffects::Transform]
     return if !isConst?(@id,PBMoves,:RELICSONG)
-    return if !isConst?(user.species,PBSpecies,:MELOETTA)
+    return if !user.isSpecies?(:MELOETTA)
     return if user.hasActiveAbility?(:SHEERFORCE) && @addlEffect>0
     newForm = (oldForm+1)%2
     user.pbChangeForm(newForm,_INTL("{1} transformed!",user.pbThis))

--- a/Data/Scripts/012_Battle/002_Move/006_Move_Effects_080-0FF.rb
+++ b/Data/Scripts/012_Battle/002_Move/006_Move_Effects_080-0FF.rb
@@ -1969,7 +1969,7 @@ class PokeBattle_Move_0C0 < PokeBattle_Move
 
   def pbNumHits(user,targets)
     if isConst?(@id,PBMoves,:WATERSHURIKEN) &&
-       isConst?(user.species,PBSpecies,:GRENINJA) && user.form==1
+       user.isSpecies?(:GRENINJA) && user.form==1
       return 3
     end
     hitChances = [2,2,3,3,4,5]
@@ -1980,7 +1980,7 @@ class PokeBattle_Move_0C0 < PokeBattle_Move
 
   def pbBaseDamage(baseDmg,user,target)
     if isConst?(@id,PBMoves,:WATERSHURIKEN) &&
-       isConst?(user.species,PBSpecies,:GRENINJA) && user.form==1
+       user.isSpecies?(:GRENINJA) && user.form==1
       return 20
     end
     return super

--- a/Data/Scripts/012_Battle/002_Move/007_Move_Effects_100-17F.rb
+++ b/Data/Scripts/012_Battle/002_Move/007_Move_Effects_100-17F.rb
@@ -730,11 +730,11 @@ class PokeBattle_Move_11A < PokeBattle_Move
       @battle.pbDisplay(_INTL("But it failed!"))
       return true
     end
-    if isConst?(target.species,PBSpecies,:DIGLETT) ||
-       isConst?(target.species,PBSpecies,:DUGTRIO) ||
-       isConst?(target.species,PBSpecies,:SANDYGAST) ||
-       isConst?(target.species,PBSpecies,:PALOSSAND) ||
-       (isConst?(target.species,PBSpecies,:GENGAR) && target.mega?)
+    if target.isSpecies?(:DIGLETT) ||
+       target.isSpecies?(:DUGTRIO) ||
+       target.isSpecies?(:SANDYGAST) ||
+       target.isSpecies?(:PALOSSAND) ||
+       (target.isSpecies?(:GENGAR) && target.mega?)
       @battle.pbDisplay(_INTL("But it failed!"))
       return true
     end
@@ -1202,7 +1202,7 @@ class PokeBattle_Move_13B < PokeBattle_StatDownMove
   end
 
   def pbMoveFailed?(user,targets)
-    if !isConst?(user.species,PBSpecies,:HOOPA)
+    if !user.isSpecies?(:HOOPA)
       @battle.pbDisplay(_INTL("But {1} can't use the move!",user.pbThis(true)))
       return true
     elsif user.form!=1

--- a/Data/Scripts/012_Battle/003_Battle/001_PokeBattle_BattleCommon.rb
+++ b/Data/Scripts/012_Battle/003_Battle/001_PokeBattle_BattleCommon.rb
@@ -170,17 +170,17 @@ module PokeBattle_BattleCommon
       rareness = pbGetSpeciesData(pkmn.species,pkmn.form,SpeciesRareness)
     end
     # Modify rareness depending on the Poké Ball's effect
-    ultraBeast = (isConst?(battler.species,PBSpecies,:NIHILEGO) ||
-       isConst?(battler.species,PBSpecies,:BUZZWOLE) ||
-       isConst?(battler.species,PBSpecies,:PHEROMOSA) ||
-       isConst?(battler.species,PBSpecies,:XURKITREE) ||
-       isConst?(battler.species,PBSpecies,:CELESTEELA) ||
-       isConst?(battler.species,PBSpecies,:KARTANA) ||
-       isConst?(battler.species,PBSpecies,:GUZZLORD) ||
-       isConst?(battler.species,PBSpecies,:POIPOLE) ||
-       isConst?(battler.species,PBSpecies,:NAGANADEL) ||
-       isConst?(battler.species,PBSpecies,:STAKATAKA) ||
-       isConst?(battler.species,PBSpecies,:BLACEPHALON))
+    ultraBeast = (battler.isSpecies?(:NIHILEGO) ||
+       battler.isSpecies?(:BUZZWOLE) ||
+       battler.isSpecies?(:PHEROMOSA) ||
+       battler.isSpecies?(:XURKITREE) ||
+       battler.isSpecies?(:CELESTEELA) ||
+       battler.isSpecies?(:KARTANA) ||
+       battler.isSpecies?(:GUZZLORD) ||
+       battler.isSpecies?(:POIPOLE) ||
+       battler.isSpecies?(:NAGANADEL) ||
+       battler.isSpecies?(:STAKATAKA) ||
+       battler.isSpecies?(:BLACEPHALON))
     if !ultraBeast || isConst?(ball,PBItems,:BEASTBALL)
       rareness = BallHandlers.modifyCatchRate(ball,rareness,self,battler,ultraBeast)
     else

--- a/Data/Scripts/012_Battle/003_Battle/009_Battle_Action_Other.rb
+++ b/Data/Scripts/012_Battle/003_Battle/009_Battle_Action_Other.rb
@@ -157,7 +157,7 @@ class PokeBattle_Battle
     side  = battler.idxOwnSide
     owner = pbGetOwnerIndexFromBattlerIndex(idxBattler)
     @megaEvolution[side][owner] = -2
-    if isConst?(battler.species,PBSpecies,:GENGAR) && battler.mega?
+    if battler.isSpecies?(:GENGAR) && battler.mega?
       battler.effects[PBEffects::Telekinesis] = 0
     end
     pbCalculatePriority(false,[idxBattler]) if NEWEST_BATTLE_MECHANICS
@@ -172,9 +172,9 @@ class PokeBattle_Battle
     battler = @battlers[idxBattler]
     return if !battler || !battler.pokemon
     return if !battler.hasPrimal? || battler.primal?
-    if isConst?(battler.pokemon.species,PBSpecies,:KYOGRE)
+    if battler.isSpecies?(:KYOGRE)
       pbCommonAnimation("PrimalKyogre",battler)
-    elsif isConst?(battler.pokemon.species,PBSpecies,:GROUDON)
+    elsif battler.isSpecies?(:GROUDON)
       pbCommonAnimation("PrimalGroudon",battler)
     end
     battler.pokemon.makePrimal
@@ -182,9 +182,9 @@ class PokeBattle_Battle
     battler.pbUpdate(true)
     @scene.pbChangePokemon(battler,battler.pokemon)
     @scene.pbRefreshOne(idxBattler)
-    if isConst?(battler.pokemon.species,PBSpecies,:KYOGRE)
+    if battler.isSpecies?(:KYOGRE)
       pbCommonAnimation("PrimalKyogre2",battler)
-    elsif isConst?(battler.pokemon.species,PBSpecies,:GROUDON)
+    elsif battler.isSpecies?(:GROUDON)
       pbCommonAnimation("PrimalGroudon2",battler)
     end
     pbDisplay(_INTL("{1}'s Primal Reversion!\nIt reverted to its primal form!",battler.pbThis))

--- a/Data/Scripts/012_Battle/004_AI/005_AI_Move_EffectScores.rb
+++ b/Data/Scripts/012_Battle/004_AI/005_AI_Move_EffectScores.rb
@@ -2627,7 +2627,7 @@ class PokeBattle_AI
       score += avg/2
     #---------------------------------------------------------------------------
     when "13B"
-      if !isConst?(user.species,PBSpecies,:HOOPA) || user.form!=1
+      if !user.isSpecies?(:HOOPA) || user.form!=1
         score -= 100
       else
         score += 20 if target.stages[PBStats::DEFENSE]>0

--- a/Data/Scripts/012_Battle/005_Battle scene/004_PokeBattle_SceneElements.rb
+++ b/Data/Scripts/012_Battle/005_Battle scene/004_PokeBattle_SceneElements.rb
@@ -234,9 +234,9 @@ class PokemonDataBox < SpriteWrapper
       imagePos.push(["Graphics/Pictures/Battle/icon_mega",@spriteBaseX+8,34])
     elsif @battler.primal?
       primalX = (@battler.opposes?) ? 208 : -28   # Foe's/player's
-      if isConst?(@battler.pokemon.species,PBSpecies,:KYOGRE)
+      if @battler.isSpecies?(:KYOGRE)
         imagePos.push(["Graphics/Pictures/Battle/icon_primal_Kyogre",@spriteBaseX+primalX,4])
-      elsif isConst?(@battler.pokemon.species,PBSpecies,:GROUDON)
+      elsif @battler.isSpecies?(:GROUDON)
         imagePos.push(["Graphics/Pictures/Battle/icon_primal_Groudon",@spriteBaseX+primalX,4])
       end
     end

--- a/Data/Scripts/012_Battle/007_BattleHandlers_Abilities.rb
+++ b/Data/Scripts/012_Battle/007_BattleHandlers_Abilities.rb
@@ -119,7 +119,7 @@ BattleHandlers::AbilityOnHPDroppedBelowHalf.copy(:EMERGENCYEXIT,:WIMPOUT)
 
 BattleHandlers::StatusCheckAbilityNonIgnorable.add(:COMATOSE,
   proc { |ability,battler,status|
-    next false if !isConst?(battler.species,PBSpecies,:KOMALA)
+    next false if !battler.isSpecies?(:KOMALA)
     next true if status.nil? || status==PBStatuses::SLEEP
   }
 )
@@ -181,13 +181,13 @@ BattleHandlers::StatusImmunityAbility.copy(:WATERVEIL,:WATERBUBBLE)
 
 BattleHandlers::StatusImmunityAbilityNonIgnorable.add(:COMATOSE,
   proc { |ability,battler,status|
-    next true if isConst?(battler.species,PBSpecies,:KOMALA)
+    next true if battler.isSpecies?(:KOMALA)
   }
 )
 
 BattleHandlers::StatusImmunityAbilityNonIgnorable.add(:SHIELDSDOWN,
   proc { |ability,battler,status|
-    next true if isConst?(battler.species,PBSpecies,:MINIOR) && battler.form<7
+    next true if battler.isSpecies?(:MINIOR) && battler.form<7
   }
 )
 

--- a/Data/Scripts/012_Battle/008_BattleHandlers_Items.rb
+++ b/Data/Scripts/012_Battle/008_BattleHandlers_Items.rb
@@ -20,7 +20,7 @@ BattleHandlers::SpeedCalcItem.copy(:MACHOBRACE,:POWERANKLET,:POWERBAND,
 
 BattleHandlers::SpeedCalcItem.add(:QUICKPOWDER,
   proc { |item,battler,mult|
-    next mult*2 if isConst?(battler.species,PBSpecies,:DITTO) &&
+    next mult*2 if battler.isSpecies?(:DITTO) &&
                    !battler.effects[PBEffects::Transform]
   }
 )
@@ -442,7 +442,7 @@ BattleHandlers::AccuracyCalcTargetItem.copy(:BRIGHTPOWDER,:LAXINCENSE)
 
 BattleHandlers::DamageCalcUserItem.add(:ADAMANTORB,
   proc { |item,user,target,move,mults,baseDmg,type|
-    if isConst?(user.species,PBSpecies,:DIALGA) &&
+    if user.isSpecies?(:DIALGA) &&
        (isConst?(type,PBTypes,:DRAGON) || isConst?(type,PBTypes,:STEEL))
       mults[BASE_DMG_MULT] = (mults[BASE_DMG_MULT]*1.2).round
     end
@@ -499,7 +499,7 @@ BattleHandlers::DamageCalcUserItem.add(:DARKGEM,
 
 BattleHandlers::DamageCalcUserItem.add(:DEEPSEATOOTH,
   proc { |item,user,target,move,mults,baseDmg,type|
-    if isConst?(user.species,PBSpecies,:CLAMPERL) && move.specialMove?
+    if user.isSpecies?(:CLAMPERL) && move.specialMove?
       mults[ATK_MULT] *= 2
     end
   }
@@ -571,7 +571,7 @@ BattleHandlers::DamageCalcUserItem.add(:GRASSGEM,
 
 BattleHandlers::DamageCalcUserItem.add(:GRISEOUSORB,
   proc { |item,user,target,move,mults,baseDmg,type|
-    if isConst?(user.species,PBSpecies,:GIRATINA) &&
+    if user.isSpecies?(:GIRATINA) &&
        (isConst?(type,PBTypes,:DRAGON) || isConst?(type,PBTypes,:GHOST))
       mults[BASE_DMG_MULT] = (mults[BASE_DMG_MULT]*1.2).round
     end
@@ -608,7 +608,7 @@ BattleHandlers::DamageCalcUserItem.add(:LIFEORB,
 
 BattleHandlers::DamageCalcUserItem.add(:LIGHTBALL,
   proc { |item,user,target,move,mults,baseDmg,type|
-    if isConst?(user.species,PBSpecies,:PIKACHU)
+    if user.isSpecies?(:PIKACHU)
       mults[ATK_MULT] *= 2
     end
   }
@@ -616,7 +616,7 @@ BattleHandlers::DamageCalcUserItem.add(:LIGHTBALL,
 
 BattleHandlers::DamageCalcUserItem.add(:LUSTROUSORB,
   proc { |item,user,target,move,mults,baseDmg,type|
-    if isConst?(user.species,PBSpecies,:PALKIA) &&
+    if user.isSpecies?(:PALKIA) &&
        (isConst?(type,PBTypes,:DRAGON) || isConst?(type,PBTypes,:WATER))
       mults[BASE_DMG_MULT] = (mults[BASE_DMG_MULT]*1.2).round
     end
@@ -746,8 +746,7 @@ BattleHandlers::DamageCalcUserItem.copy(:SOFTSAND,:EARTHPLATE)
 
 BattleHandlers::DamageCalcUserItem.add(:SOULDEW,
   proc { |item,user,target,move,mults,baseDmg,type|
-    next if !isConst?(user.species,PBSpecies,:LATIAS) &&
-            !isConst?(user.species,PBSpecies,:LATIOS)
+    next if !user.isSpecies?(:LATIAS) && !user.isSpecies?(:LATIOS)
     if NEWEST_BATTLE_MECHANICS
       if isConst?(type,PBTypes,:PSYCHIC) || isConst?(type,PBTypes,:DRAGON)
         mults[FINAL_DMG_MULT] = (mults[FINAL_DMG_MULT]*1.2).round
@@ -776,8 +775,7 @@ BattleHandlers::DamageCalcUserItem.add(:STEELGEM,
 
 BattleHandlers::DamageCalcUserItem.add(:THICKCLUB,
   proc { |item,user,target,move,mults,baseDmg,type|
-    if (isConst?(user.species,PBSpecies,:CUBONE) ||
-       isConst?(user.species,PBSpecies,:MAROWAK)) && move.physicalMove?
+    if (user.isSpecies?(:CUBONE) || user.isSpecies?(:MAROWAK)) && move.physicalMove?
       mults[ATK_MULT] *= 2
     end
   }
@@ -969,7 +967,7 @@ BattleHandlers::DamageCalcTargetItem.add(:YACHEBERRY,
 
 BattleHandlers::CriticalCalcUserItem.add(:LUCKYPUNCH,
   proc { |item,user,target,c|
-    next c+2 if isConst?(user.species,PBSpecies,:CHANSEY)
+    next c+2 if user.isSpecies?(:CHANSEY)
   }
 )
 
@@ -983,7 +981,7 @@ BattleHandlers::CriticalCalcUserItem.copy(:RAZORCLAW,:SCOPELENS)
 
 BattleHandlers::CriticalCalcUserItem.add(:STICK,
   proc { |item,user,target,c|
-    next c+2 if isConst?(user.species,PBSpecies,:FARFETCHD)
+    next c+2 if user.isSpecies?(:FARFETCHD)
   }
 )
 

--- a/Data/Scripts/015_Items/002_PItem_ItemEffects.rb
+++ b/Data/Scripts/015_Items/002_PItem_ItemEffects.rb
@@ -837,7 +837,7 @@ ItemHandlers::UseOnPokemon.add(:TAMATOBERRY,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:GRACIDEA,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:SHAYMIN) || pkmn.form!=0 ||
+  if !pkmn.isSpecies?(:SHAYMIN) || pkmn.form!=0 ||
      pkmn.status==PBStatuses::FROZEN || PBDayNight.isNight?
     scene.pbDisplay(_INTL("It had no effect."))
     next false
@@ -854,7 +854,7 @@ ItemHandlers::UseOnPokemon.add(:GRACIDEA,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:REDNECTAR,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:ORICORIO) || pkmn.form==0
+  if !pkmn.isSpecies?(:ORICORIO) || pkmn.form==0
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -869,7 +869,7 @@ ItemHandlers::UseOnPokemon.add(:REDNECTAR,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:YELLOWNECTAR,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:ORICORIO) || pkmn.form==1
+  if !pkmn.isSpecies?(:ORICORIO) || pkmn.form==1
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -884,7 +884,7 @@ ItemHandlers::UseOnPokemon.add(:YELLOWNECTAR,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:PINKNECTAR,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:ORICORIO) || pkmn.form==2
+  if !pkmn.isSpecies?(:ORICORIO) || pkmn.form==2
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -899,7 +899,7 @@ ItemHandlers::UseOnPokemon.add(:PINKNECTAR,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:PURPLENECTAR,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:ORICORIO) || pkmn.form==3
+  if !pkmn.isSpecies?(:ORICORIO) || pkmn.form==3
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -914,9 +914,9 @@ ItemHandlers::UseOnPokemon.add(:PURPLENECTAR,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:REVEALGLASS,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:TORNADUS) &&
-     !isConst?(pkmn.species,PBSpecies,:THUNDURUS) &&
-     !isConst?(pkmn.species,PBSpecies,:LANDORUS)
+  if !pkmn.isSpecies?(:TORNADUS) &&
+     !pkmn.isSpecies?(:THUNDURUS) &&
+     !pkmn.isSpecies?(:LANDORUS)
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -933,7 +933,7 @@ ItemHandlers::UseOnPokemon.add(:REVEALGLASS,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:PRISONBOTTLE,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:HOOPA)
+  if !pkmn.isSpecies?(:HOOPA)
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -949,7 +949,7 @@ ItemHandlers::UseOnPokemon.add(:PRISONBOTTLE,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:DNASPLICERS,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:KYUREM)
+  if !pkmn.isSpecies?(:KYUREM)
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -967,13 +967,13 @@ ItemHandlers::UseOnPokemon.add(:DNASPLICERS,proc { |item,pkmn,scene|
       scene.pbDisplay(_INTL("It cannot be fused with an Egg."))
     elsif poke2.fainted?
       scene.pbDisplay(_INTL("It cannot be fused with that fainted Pokémon."))
-    elsif !isConst?(poke2.species,PBSpecies,:RESHIRAM) &&
-          !isConst?(poke2.species,PBSpecies,:ZEKROM)
+    elsif !poke2.isSpecies?(:RESHIRAM) &&
+          !poke2.isSpecies?(:ZEKROM)
       scene.pbDisplay(_INTL("It cannot be fused with that Pokémon."))
     end
     newForm = 0
-    newForm = 1 if isConst?(poke2.species,PBSpecies,:RESHIRAM)
-    newForm = 2 if isConst?(poke2.species,PBSpecies,:ZEKROM)
+    newForm = 1 if poke2.isSpecies?(:RESHIRAM)
+    newForm = 2 if poke2.isSpecies?(:ZEKROM)
     pkmn.setForm(newForm) {
       pkmn.fused = poke2
       pbRemovePokemonAt(chosen)
@@ -997,7 +997,7 @@ ItemHandlers::UseOnPokemon.add(:DNASPLICERS,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:NSOLARIZER,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:NECROZMA) || pkmn.form==0
+  if !pkmn.isSpecies?(:NECROZMA) || pkmn.form==0
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -1015,7 +1015,7 @@ ItemHandlers::UseOnPokemon.add(:NSOLARIZER,proc { |item,pkmn,scene|
       scene.pbDisplay(_INTL("It cannot be fused with an Egg."))
     elsif poke2.fainted?
       scene.pbDisplay(_INTL("It cannot be fused with that fainted Pokémon."))
-    elsif !isConst?(poke2.species,PBSpecies,:SOLGALEO)
+    elsif !poke2.isSpecies?(:SOLGALEO)
       scene.pbDisplay(_INTL("It cannot be fused with that Pokémon."))
     end
     pkmn.setForm(1) {
@@ -1041,7 +1041,7 @@ ItemHandlers::UseOnPokemon.add(:NSOLARIZER,proc { |item,pkmn,scene|
 })
 
 ItemHandlers::UseOnPokemon.add(:NLUNARIZER,proc { |item,pkmn,scene|
-  if !isConst?(pkmn.species,PBSpecies,:NECROZMA) || pkmn.form==1
+  if !pkmn.isSpecies?(:NECROZMA) || pkmn.form==1
     scene.pbDisplay(_INTL("It had no effect."))
     next false
   end
@@ -1059,7 +1059,7 @@ ItemHandlers::UseOnPokemon.add(:NLUNARIZER,proc { |item,pkmn,scene|
       scene.pbDisplay(_INTL("It cannot be fused with an Egg."))
     elsif poke2.fainted?
       scene.pbDisplay(_INTL("It cannot be fused with that fainted Pokémon."))
-    elsif !isConst?(poke2.species,PBSpecies,:LUNALA)
+    elsif !poke2.isSpecies?(:LUNALA)
       scene.pbDisplay(_INTL("It cannot be fused with that Pokémon."))
     end
     pkmn.setForm(2) {
@@ -1091,8 +1091,7 @@ ItemHandlers::UseOnPokemon.add(:ABILITYCAPSULE,proc { |item,pkmn,scene|
     abil1 = i[0] if i[1]==0
     abil2 = i[0] if i[1]==1
   end
-  if abil1<=0 || abil2<=0 || pkmn.hasHiddenAbility? ||
-     isConst?(pkmn.species,PBSpecies,:ZYGARDE)
+  if abil1<=0 || abil2<=0 || pkmn.hasHiddenAbility? || pkmn.isSpecies?(:ZYGARDE)
     scene.pbDisplay(_INTL("It won't have any effect."))
     next false
   end

--- a/Data/Scripts/016_Pokemon/004_Pokemon_ShadowPokemon.rb
+++ b/Data/Scripts/016_Pokemon/004_Pokemon_ShadowPokemon.rb
@@ -193,7 +193,7 @@ end
 #===============================================================================
 def pbIsPurifiable?(pkmn)
   return false if !pkmn
-  return false if isConst?(pkmn.species,PBSpecies,:LUGIA)
+  return false if pkmn.isSpecies?(:LUGIA)
   return false if !pkmn.shadowPokemon? || pkmn.heartgauge>0
   return true
 end

--- a/Data/Scripts/016_Pokemon/008_Pokemon_Storage.rb
+++ b/Data/Scripts/016_Pokemon/008_Pokemon_Storage.rb
@@ -181,7 +181,7 @@ class PokemonStorage
       pkmn = self[boxSrc,indexSrc]
       raise "Trying to copy nil to storage" if !pkmn
       pkmn.formTime = nil if pkmn.respond_to?("formTime")
-      pkmn.form     = 0 if isConst?(pkmn.species,PBSpecies,:SHAYMIN)
+      pkmn.form     = 0 if pkmn.isSpecies?(:SHAYMIN)
       pkmn.heal
       self[boxDst,indexDst] = pkmn
     end
@@ -204,7 +204,7 @@ class PokemonStorage
       if self[box,i]==nil
         if box>=0
           pkmn.formTime = nil if pkmn.respond_to?("formTime") && pkmn.formTime
-          pkmn.form     = 0 if isConst?(pkmn.species,PBSpecies,:SHAYMIN)
+          pkmn.form     = 0 if pkmn.isSpecies?(:SHAYMIN)
           pkmn.heal
         end
         self[box,i] = pkmn
@@ -217,7 +217,7 @@ class PokemonStorage
   def pbStoreCaught(pkmn)
     if @currentBox>=0
       pkmn.formTime = nil if pkmn.respond_to?("formTime")
-      pkmn.form     = 0 if isConst?(pkmn.species,PBSpecies,:SHAYMIN)
+      pkmn.form     = 0 if pkmn.isSpecies?(:SHAYMIN)
       pkmn.heal
     end
     for i in 0...maxPokemon(@currentBox)

--- a/Data/Scripts/017_UI/017_PScreen_PokemonStorage.rb
+++ b/Data/Scripts/017_UI/017_PScreen_PokemonStorage.rb
@@ -1760,7 +1760,7 @@ class PokemonStorageScreen
     end
     if box>=0
       @heldpkmn.formTime = nil if @heldpkmn.respond_to?("formTime")
-      @heldpkmn.form     = 0 if isConst?(@heldpkmn.species,PBSpecies,:SHAYMIN)
+      @heldpkmn.form     = 0 if @heldpkmn.isSpecies?(:SHAYMIN)
       @heldpkmn.heal
     end
     @scene.pbPlace(selected,@heldpkmn)
@@ -1789,7 +1789,7 @@ class PokemonStorageScreen
     end
     if box>=0
       @heldpkmn.formTime = nil if @heldpkmn.respond_to?("formTime")
-      @heldpkmn.form     = 0 if isConst?(@heldpkmn.species,PBSpecies,:SHAYMIN)
+      @heldpkmn.form     = 0 if @heldpkmn.isSpecies?(:SHAYMIN)
       @heldpkmn.heal
     end
     @scene.pbSwap(selected,@heldpkmn)

--- a/Data/Scripts/019_Other battles/004_PBattle_OrgBattleRules.rb
+++ b/Data/Scripts/019_Other battles/004_PBattle_OrgBattleRules.rb
@@ -405,12 +405,12 @@ class StandardRestriction
     # Certain named species are not banned
     speciesWhitelist = [:DRAGONITE,:SALAMENCE,:TYRANITAR]
     for i in speciesWhitelist
-      return true if isConst?(pokemon.species,PBSpecies,i)
+      return true if pokemon.isSpecies?(i)
     end
     # Certain named species are banned
     speciesBlacklist = [:WYNAUT,:WOBBUFFET]
     for i in speciesBlacklist
-      return false if isConst?(pokemon.species,PBSpecies,i)
+      return false if pokemon.isSpecies?(i)
     end
     # Species with total base stat 600 or more are banned
     baseStats = pbGetSpeciesData(pokemon.species,pokemon.form,SpeciesBaseStats)
@@ -498,7 +498,7 @@ end
 
 class NegativeExtendedGameClause
   def isValid?(pokemon)
-    return false if isConst?(pokemon.species,PBSpecies,:ARCEUS)
+    return false if pokemon.isSpecies?(:ARCEUS)
     return false if isConst?(pokemon.item,PBItems,:MICLEBERRY)
     return false if isConst?(pokemon.item,PBItems,:CUSTAPBERRY)
     return false if isConst?(pokemon.item,PBItems,:JABOCABERRY)
@@ -605,12 +605,12 @@ class LittleCupRestriction
     return false if isConst?(pokemon.item,PBItems,:DEEPSEATOOTH)
     return false if pokemon.hasMove?(:SONICBOOM)
     return false if pokemon.hasMove?(:DRAGONRAGE)
-    return false if isConst?(pokemon.species,PBSpecies,:SCYTHER)
-    return false if isConst?(pokemon.species,PBSpecies,:SNEASEL)
-    return false if isConst?(pokemon.species,PBSpecies,:MEDITITE)
-    return false if isConst?(pokemon.species,PBSpecies,:YANMA)
-    return false if isConst?(pokemon.species,PBSpecies,:TANGELA)
-    return false if isConst?(pokemon.species,PBSpecies,:MURKROW)
+    return false if pokemon.isSpecies?(:SCYTHER)
+    return false if pokemon.isSpecies?(:SNEASEL)
+    return false if pokemon.isSpecies?(:MEDITITE)
+    return false if pokemon.isSpecies?(:YANMA)
+    return false if pokemon.isSpecies?(:TANGELA)
+    return false if pokemon.isSpecies?(:MURKROW)
     return true
   end
 end


### PR DESCRIPTION
`isConst?(pkmn.species,PBSpecies,species)` and `isConst?(battler.species,PBSpecies,species)` are used extensively in Essentials's code. v18 added the `PokeBattle_Pokemon#isSpecies?` method, and I would like to propose using it instead of `isConst?`.

I've added `PokeBattle_Battler#isSpecies?`, which uses the new `isSpecies?` method:
```ruby
def isSpecies?(species)
  return @pokemon && @pokemon.isSpecies?(species)
end
```

I've replaced every isConst? species check with the new methods. It should make the code easier to work with.