### PR TITLE
Refactor PokeBattle_Pokemon#hasItem? and use it instead of Object.isConst?

### DIFF
--- a/Data/Scripts/012_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
+++ b/Data/Scripts/012_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
@@ -25,7 +25,7 @@ class PokeBattle_Battle
       if !expAll
         eachInTeam(0,0) do |pkmn,i|
           next if !pkmn.able?
-          next if !isConst?(pkmn.item,PBItems,:EXPSHARE) &&
+          next if !pkmn.hasItem?(:EXPSHARE) &&
                   !isConst?(@initialItems[0][i],PBItems,:EXPSHARE)
           expShare.push(i)
         end

--- a/Data/Scripts/013_Overworld/013_PField_DayCare.rb
+++ b/Data/Scripts/013_Overworld/013_PField_DayCare.rb
@@ -282,12 +282,12 @@ def pbDayCareGenerateEgg
   lightball = false
   if (isConst?(father.species,PBSpecies,:PIKACHU) ||
       isConst?(father.species,PBSpecies,:RAICHU)) &&
-      isConst?(father.item,PBItems,:LIGHTBALL)
+      father.hasItem?(:LIGHTBALL)
     lightball = true
   end
   if (isConst?(mother.species,PBSpecies,:PIKACHU) ||
       isConst?(mother.species,PBSpecies,:RAICHU)) &&
-      isConst?(mother.item,PBItems,:LIGHTBALL)
+      mother.hasItem?(:LIGHTBALL)
     lightball = true
   end
   if lightball && isConst?(babyspecies,PBSpecies,:PICHU) &&
@@ -313,12 +313,12 @@ def pbDayCareGenerateEgg
   ivinherit = []
   for i in 0...2
     parent = [mother,father][i]
-    ivinherit[i] = PBStats::HP if isConst?(parent.item,PBItems,:POWERWEIGHT)
-    ivinherit[i] = PBStats::ATTACK if isConst?(parent.item,PBItems,:POWERBRACER)
-    ivinherit[i] = PBStats::DEFENSE if isConst?(parent.item,PBItems,:POWERBELT)
-    ivinherit[i] = PBStats::SPATK if isConst?(parent.item,PBItems,:POWERLENS)
-    ivinherit[i] = PBStats::SPDEF if isConst?(parent.item,PBItems,:POWERBAND)
-    ivinherit[i] = PBStats::SPEED if isConst?(parent.item,PBItems,:POWERANKLET)
+    ivinherit[i] = PBStats::HP if parent.hasItem?(:POWERWEIGHT)
+    ivinherit[i] = PBStats::ATTACK if parent.hasItem?(:POWERBRACER)
+    ivinherit[i] = PBStats::DEFENSE if parent.hasItem?(:POWERBELT)
+    ivinherit[i] = PBStats::SPATK if parent.hasItem?(:POWERLENS)
+    ivinherit[i] = PBStats::SPDEF if parent.hasItem?(:POWERBAND)
+    ivinherit[i] = PBStats::SPEED if parent.hasItem?(:POWERANKLET)
   end
   num = 0; r = rand(2)
   for i in 0...2
@@ -330,8 +330,8 @@ def pbDayCareGenerateEgg
     end
     r = (r+1)%2
   end
-  limit = (NEWEST_BATTLE_MECHANICS && (isConst?(mother.item,PBItems,:DESTINYKNOT) ||
-           isConst?(father.item,PBItems,:DESTINYKNOT))) ? 5 : 3
+  limit = (NEWEST_BATTLE_MECHANICS && (mother.hasItem?(:DESTINYKNOT) ||
+           father.hasItem?(:DESTINYKNOT))) ? 5 : 3
   loop do
     freestats = []
     PBStats.eachStat { |s| freestats.push(s) if !ivinherit.include?(s) }
@@ -345,8 +345,8 @@ def pbDayCareGenerateEgg
   end
   # Inheriting nature
   newnatures = []
-  newnatures.push(mother.nature) if isConst?(mother.item,PBItems,:EVERSTONE)
-  newnatures.push(father.nature) if isConst?(father.item,PBItems,:EVERSTONE)
+  newnatures.push(mother.nature) if mother.hasItem?(:EVERSTONE)
+  newnatures.push(father.nature) if father.hasItem?(:EVERSTONE)
   if newnatures.length>0
     egg.setNature(newnatures[rand(newnatures.length)])
   end

--- a/Data/Scripts/015_Items/001_PItem_Items.rb
+++ b/Data/Scripts/015_Items/001_PItem_Items.rb
@@ -826,7 +826,7 @@ def pbGiveItemToPokemon(item,pkmn,scene,pkmnid=0)
   end
   if pkmn.hasItem?
     olditemname = PBItems.getName(pkmn.item)
-    if isConst?(pkmn.item,PBItems,:LEFTOVERS)
+    if pkmn.hasItem?(:LEFTOVERS)
       scene.pbDisplay(_INTL("{1} is already holding some {2}.\1",pkmn.name,olditemname))
     elsif newitemname.starts_with_vowel?
       scene.pbDisplay(_INTL("{1} is already holding an {2}.\1",pkmn.name,olditemname))

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -596,10 +596,10 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Returns whether this Pokémon is holding an item. If an item id is passed,
   # returns whether the Pokémon is holding that item.
-  def hasItem?(item = 0)
+  def hasItem?(item_id = 0)
     held_item = self.item
-    return held_item > 0 if item == 0
-    return held_item == getID(PBItems,item)
+    return held_item > 0 if item_id == 0
+    return held_item == getID(PBItems,item_id)
   end
 
   # Sets this Pokémon's item. Accepts symbols.

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -594,11 +594,12 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Items
   #=============================================================================
-  # Returns whether this Pokémon has a hold item.
-  def hasItem?(value=0)
-    itm = self.item
-    return itm>0 if value==0
-    return itm==getID(PBItems,value)
+  # Returns whether this Pokémon is holding an item. If an item id is passed,
+  # returns whether the Pokémon is holding that item.
+  def hasItem?(item = 0)
+    held_item = self.item
+    return held_item > 0 if item == 0
+    return held_item == getID(PBItems,item)
   end
 
   # Sets this Pokémon's item. Accepts symbols.

--- a/Data/Scripts/016_Pokemon/002_Pokemon_Forms.rb
+++ b/Data/Scripts/016_Pokemon/002_Pokemon_Forms.rb
@@ -330,8 +330,7 @@ MultipleForms.register(:ROTOM,{
 MultipleForms.register(:GIRATINA,{
   "getForm" => proc { |pkmn|
     maps = [49,50,51,72,73]   # Map IDs for Origin Forme
-    if isConst?(pkmn.item,PBItems,:GRISEOUSORB) ||
-       maps.include?($game_map.map_id)
+    if pkmn.hasItem?(:GRISEOUSORB) || maps.include?($game_map.map_id)
       next 1
     end
     next 0
@@ -369,8 +368,8 @@ MultipleForms.register(:ARCEUS,{
     }
     ret = 0
     typeArray.each do |f, items|
-      for i in items
-        next if !isConst?(pkmn.item,PBItems,i)
+      for item in items
+        next if !pkmn.hasItem?(item)
         ret = f
         break
       end
@@ -460,10 +459,10 @@ MultipleForms.register(:MELOETTA,{
 
 MultipleForms.register(:GENESECT,{
   "getForm" => proc { |pkmn|
-    next 1 if isConst?(pkmn.item,PBItems,:SHOCKDRIVE)
-    next 2 if isConst?(pkmn.item,PBItems,:BURNDRIVE)
-    next 3 if isConst?(pkmn.item,PBItems,:CHILLDRIVE)
-    next 4 if isConst?(pkmn.item,PBItems,:DOUSEDRIVE)
+    next 1 if pkmn.hasItem?(:SHOCKDRIVE)
+    next 2 if pkmn.hasItem?(:BURNDRIVE)
+    next 3 if pkmn.hasItem?(:CHILLDRIVE)
+    next 4 if pkmn.hasItem?(:DOUSEDRIVE)
     next 0
   }
 })
@@ -606,8 +605,8 @@ MultipleForms.register(:SILVALLY,{
     }
     ret = 0
     typeArray.each do |f, items|
-      for i in items
-        next if !isConst?(pkmn.item,PBItems,i)
+      for item in items
+        next if !pkmn.hasItem?(item)
         ret = f
         break
       end

--- a/Data/Scripts/016_Pokemon/003_Pokemon_MegaEvolution.rb
+++ b/Data/Scripts/016_Pokemon/003_Pokemon_MegaEvolution.rb
@@ -97,14 +97,14 @@ end
 
 MultipleForms.register(:GROUDON,{
   "getPrimalForm" => proc { |pkmn|
-    next 1 if isConst?(pkmn.item,PBItems,:REDORB)
+    next 1 if pkmn.hasItem?(:REDORB)
     next
   }
 })
 
 MultipleForms.register(:KYOGRE,{
   "getPrimalForm" => proc { |pkmn|
-    next 1 if isConst?(pkmn.item,PBItems,:BLUEORB)
+    next 1 if pkmn.hasItem?(:BLUEORB)
     next
   }
 })

--- a/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
+++ b/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
@@ -309,7 +309,7 @@ end
 #   Pokemon to check; evolution type; level or other parameter; ID of the new species
 def pbCheckEvolutionEx(pokemon)
   return -1 if pokemon.species<=0 || pokemon.egg? || pokemon.shadowPokemon?
-  return -1 if isConst?(pokemon.item,PBItems,:EVERSTONE)
+  return -1 if pokemon.hasItem?(:EVERSTONE)
   return -1 if isConst?(pokemon.ability,PBAbilities,:BATTLEBOND)
   ret = -1
   for form in pbGetEvolvedFormData(pbGetFSpeciesFromForm(pokemon.species,pokemon.form),true)

--- a/Data/Scripts/017_UI/022_PScreen_Trading.rb
+++ b/Data/Scripts/017_UI/022_PScreen_Trading.rb
@@ -238,7 +238,7 @@ def pbTradeCheckEvolution(pokemon,pokemon2)
         next poke
       end
     when PBEvolution::TradeSpecies
-      if !isConst?(pokemon2.item,PBItems,:EVERSTONE)
+      if !pokemon2.hasItem?(:EVERSTONE)
         next poke if pokemon2.species==level
       end
     end

--- a/Data/Scripts/019_Other battles/004_PBattle_OrgBattleRules.rb
+++ b/Data/Scripts/019_Other battles/004_PBattle_OrgBattleRules.rb
@@ -482,7 +482,7 @@ end
 
 class SoulDewClause
   def isValid?(pokemon)
-    return !isConst?(pokemon.item,PBItems,:SOULDEW)
+    return !pokemon.hasItem?(:SOULDEW)
   end
 end
 
@@ -499,10 +499,10 @@ end
 class NegativeExtendedGameClause
   def isValid?(pokemon)
     return false if pokemon.isSpecies?(:ARCEUS)
-    return false if isConst?(pokemon.item,PBItems,:MICLEBERRY)
-    return false if isConst?(pokemon.item,PBItems,:CUSTAPBERRY)
-    return false if isConst?(pokemon.item,PBItems,:JABOCABERRY)
-    return false if isConst?(pokemon.item,PBItems,:ROWAPBERRY)
+    return false if pokemon.hasItem?(:MICLEBERRY)
+    return false if pokemon.hasItem?(:CUSTAPBERRY)
+    return false if pokemon.hasItem?(:JABOCABERRY)
+    return false if pokemon.hasItem?(:ROWAPBERRY)
   end
 end
 
@@ -601,8 +601,8 @@ end
 
 class LittleCupRestriction
   def isValid?(pokemon)
-    return false if isConst?(pokemon.item,PBItems,:BERRYJUICE)
-    return false if isConst?(pokemon.item,PBItems,:DEEPSEATOOTH)
+    return false if pokemon.hasItem?(:BERRYJUICE)
+    return false if pokemon.hasItem?(:DEEPSEATOOTH)
     return false if pokemon.hasMove?(:SONICBOOM)
     return false if pokemon.hasMove?(:DRAGONRAGE)
     return false if pokemon.isSpecies?(:SCYTHER)


### PR DESCRIPTION
I cleaned up `PokeBattle_Pokemon#hasItem?` a little (its functionality stays the same). I've also replaced all instances of `isConst?(pkmn.item,PBItems,item)` with `pkmn.hasItem?(item)`.