### PR TITLE
Refactoring and YARD-style documentation of PokeBattle_Pokemon

### DIFF
--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -60,7 +60,7 @@ class PokeBattle_Pokemon
   attr_accessor :happiness
   # @return [Integer] the type of ball used (refer to {$BallTypes} for valid types)
   attr_accessor :ballused
-  # @return [Integer] the number of steps until the egg hatches, 0 if Pokémon is not an egg
+  # @return [Integer] the number of steps until this Pokémon hatches, 0 if this Pokémon is not an egg
   attr_accessor :eggsteps
   # @param value [Integer] new markings for this Pokémon
   attr_writer   :markings

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -403,11 +403,11 @@ class PokeBattle_Pokemon
 
   # Returns the Pokérus infection stage for this Pokémon.
   # @return [0, 1, 2] Pokérus infection stage
-  #   (0 = not infected, 1 = cured, 2 = infected)
+  #   (0 = not infected, 1 = infected, 2 = cured)
   def pokerusStage
-    return 0 if !@pokerus || @pokerus==0        # Not infected
-    return 2 if @pokerus>0 && (@pokerus%16)==0  # Cured
-    return 1                                    # Infected
+    return 0 if !@pokerus || @pokerus==0
+    return 2 if @pokerus > 0 && (@pokerus % 16) == 0
+    return 1
   end
 
   # Gives this Pokémon Pokérus (either the specified strain or a random one).
@@ -595,6 +595,7 @@ class PokeBattle_Pokemon
     @firstmoves.delete(move) if move > 0
   end
 
+  # Clears this Pokémon's first moves.
   def pbClearFirstMoves
     @firstmoves = []
   end
@@ -608,34 +609,48 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Contest attributes, ribbons
   #=============================================================================
-  def cool;   return @cool || 0;   end
-  def beauty; return @beauty || 0; end
-  def cute;   return @cute || 0;   end
-  def smart;  return @smart || 0;  end
-  def tough;  return @tough || 0;  end
-  def sheen;  return @sheen || 0;  end
 
-  # Returns the number of ribbons this Pokémon has.
+  # @return [Integer] this Pokémon's cool contest attribute
+  def cool; return @cool || 0; end
+
+  # @return [Integer] this Pokémon's beauty contest attribute
+  def beauty; return @beauty || 0; end
+
+  # @return [Integer] this Pokémon's cute contest attribute
+  def cute; return @cute || 0; end
+
+  # @return [Integer] this Pokémon's smart contest attribute
+  def smart; return @smart || 0; end
+
+  # @return [Integer] this Pokémon's tough contest attribute
+  def tough; return @tough || 0; end
+
+  # @return [Integer] this Pokémon's sheen contest attribute
+  def sheen; return @sheen || 0; end
+  
+  # @return [Integer] the number of ribbons this Pokémon has
   def ribbonCount
     return (@ribbons) ? @ribbons.length : 0
   end
 
-  # Returns whether this Pokémon has the specified ribbon.
+  # @param ribbon [Integer, Symbol, String] ribbon id to check
+  # @return [Boolean] whether this Pokémon has the specified ribbon
   def hasRibbon?(ribbon)
     return false if !@ribbons
     ribbon = getID(PBRibbons,ribbon)
-    return false if ribbon==0
+    return false if ribbon == 0
     return @ribbons.include?(ribbon)
   end
 
-  # Gives this Pokémon the specified ribbon.
+  # @param ribbon [Integer, Symbol, String] id of the ribbon to give
   def giveRibbon(ribbon)
     @ribbons = [] if !@ribbons
     ribbon = getID(PBRibbons,ribbon)
-    return if ribbon==0
+    return if ribbon == 0
     @ribbons.push(ribbon) if !@ribbons.include?(ribbon)
   end
 
+  # TODO Figure out a good way to document this
   # Replaces one ribbon with the next one along, if possible.
   def upgradeRibbon(*arg)
     @ribbons = [] if !@ribbons
@@ -657,7 +672,7 @@ class PokeBattle_Pokemon
     return 0
   end
 
-  # Removes the specified ribbon from this Pokémon.
+  # @param ribbon [Integer, Symbol, String] id of the ribbon to remove
   def takeRibbon(ribbon)
     return if !@ribbons
     ribbon = getID(PBRibbons,ribbon)
@@ -678,20 +693,24 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Items
   #=============================================================================
+
   # Returns whether this Pokémon is holding an item. If an item id is passed,
   # returns whether the Pokémon is holding that item.
+  # @param item_id [Integer, Symbol, String] id of the item to check
+  # @return [Boolean] whether the Pokémon is holding the specified item or
+  #   an item at all
   def hasItem?(item_id = 0)
     held_item = self.item
     return held_item > 0 if item_id == 0
     return held_item == getID(PBItems,item_id)
   end
 
-  # Sets this Pokémon's item. Accepts symbols.
-  def setItem(value)
-    self.item = getID(PBItems,value)
+  # @param item_id [Integer, Symbol, String] id of the item to give to this Pokémon
+  def setItem(item_id)
+    self.item = getID(PBItems,item_id)
   end
 
-  # Returns the items this species can be found holding in the wild.
+  # @return [Array<Integer>] the items this species can be found holding in the wild
   def wildHoldItems
     ret = []
     ret.push(pbGetSpeciesData(@species,formSimple,SpeciesWildItemCommon))
@@ -703,7 +722,7 @@ class PokeBattle_Pokemon
   # @return [PokemonMail, nil] mail held by this Pokémon (nil if there is none)
   def mail
     return nil if !@mail
-    @mail = nil if @mail.item==0 || !hasItem?(@mail.item)
+    @mail = nil if @mail.item == 0 || !hasItem?(@mail.item)
     return @mail
   end
 
@@ -718,40 +737,47 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Other
   #=============================================================================
-  def species=(value)
+
+  # Changes the Pokémon's species and re-calculates its statistics.
+  # @param species_id [Integer] id of the species to change this Pokémon to
+  def species=(species_id)
     hasNickname = nicknamed?
-    @species    = value
+    @species    = species_id
     @name       = PBSpecies.getName(@species) unless hasNickname
     @level      = nil   # In case growth rate is different for the new species
     @forcedForm = nil
     calcStats
   end
 
-  def isSpecies?(s)
-    s = getID(PBSpecies,s)
-    return s && @species==s
+  # @param species [Integer, Symbol, String] id of the species to check for
+  # @return [Boolean] whether this Pokémon is of the specified species
+  def isSpecies?(species)
+    species = getID(PBSpecies,species)
+    return species && @species == species
   end
 
-  # Returns the species name of this Pokémon.
+  # @return [String] the species name of this Pokémon
   def speciesName
     return PBSpecies.getName(@species)
   end
 
+  # @return [Boolean] whether this Pokémon has been nicknamed
   def nicknamed?
-    return @name!=self.speciesName
+    return @name != self.speciesName
   end
 
-  # Returns this Pokémon's language.
+  # @return [Integer] this Pokémon's language
   def language; return @language || 0; end
 
-  # Returns the markings this Pokémon has.
+  # @return [Integer] the markings this Pokémon has
   def markings; return @markings || 0; end
 
-  # Returns a string stating the Unown form of this Pokémon.
+  # @return [String] a string stating the Unown form of this Pokémon
   def unownShape
     return "ABCDEFGHIJKLMNOPQRSTUVWXYZ?!"[@form,1]
   end
 
+  # TODO Check whether #height and #weight always return an integer
   # Returns the height of this Pokémon.
   def height
     return pbGetSpeciesData(@species,formSimple,SpeciesHeight)
@@ -786,19 +812,21 @@ class PokeBattle_Pokemon
 
   # Sets this Pokémon's HP.
   def hp=(value)
-    value = 0 if value<0
+    value = 0 if value < 0
     @hp = value
-    if @hp==0
+    if @hp == 0
       @status      = PBStatuses::NONE
       @statusCount = 0
     end
   end
 
+  # @return [Boolean] whether the Pokémon is not fainted and not an egg
   def able?
     return !egg? && @hp>0
   end
   alias isAble? able?
 
+  # @return [Boolean] whether the Pokémon is fainted
   def fainted?
     return !egg? && @hp<=0
   end
@@ -817,11 +845,14 @@ class PokeBattle_Pokemon
     @statusCount = 0
   end
 
-  # Heals all PP of this Pokémon.
-  def healPP(index=-1)
+  # Heals all PP of this Pokémon. If a move index is given, heals the PP
+  # of the move in that index.
+  # @param move_index [Integer] index of the move to heal (-1 if all moves
+  #   should be healed)
+  def healPP(move_index = -1)
     return if egg?
-    if index>=0
-      @moves[index].pp = @moves[index].totalpp
+    if move_index >= 0
+      @moves[move_index].pp = @moves[move_index].totalpp
     else
       @moves.each { |m| m.pp = m.totalpp }
     end
@@ -836,6 +867,7 @@ class PokeBattle_Pokemon
   end
 
   # Changes the happiness of this Pokémon depending on what happened to change it.
+  # @param method [String] the happiness changing method (e.g. 'walking')
   def changeHappiness(method)
     gain = 0
     case method
@@ -896,19 +928,20 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Stat calculations, Pokémon creation
   #=============================================================================
-  # Returns this Pokémon's base stats. An array of six values.
+
+  # @return [Array<Integer>] this Pokémon's base stats, an array of six values
   def baseStats
     ret = pbGetSpeciesData(@species,formSimple,SpeciesBaseStats)
     return ret.clone
   end
 
-  # Returns the maximum HP of this Pokémon.
+  # @return [Integer] the maximum HP of this Pokémon
   def calcHP(base,level,iv,ev)
-    return 1 if base==1   # For Shedinja
-    return ((base*2+iv+(ev>>2))*level/100).floor+level+10
+    return 1 if base == 1   # For Shedinja
+    return ((base * 2 + iv + (ev >> 2)) * level / 100).floor + level + 10
   end
 
-  # Returns the specified stat of this Pokémon (not used for total HP).
+  # @return [Integer] the specified stat of this Pokémon (not used for total HP)
   def calcStat(base,level,iv,ev,pv)
     return ((((base*2+iv+(ev>>2))*level/100).floor+5)*pv/100).floor
   end
@@ -939,6 +972,7 @@ class PokeBattle_Pokemon
     @speed   = stats[PBStats::SPEED]
   end
 
+  # @return [PokeBattle_Pokemon] a copy of this Pokémon
   def clone
     ret = super
     ret.iv      = @iv.clone
@@ -951,16 +985,16 @@ class PokeBattle_Pokemon
   end
 
   # Creates a new Pokémon object.
-  #    species   - Pokémon species.
-  #    level     - Pokémon level.
-  #    player    - PokeBattle_Trainer object for the original trainer.
-  #    withMoves - If false, this Pokémon has no moves.
+  # @param species [Integer, Symbol, String] Pokémon species
+  # @param level [Integer] Pokémon level
+  # @param player [PokeBattle_Trainer] object for the original trainer
+  # @param withMoves [Boolean] whether the Pokémon should have moves
   def initialize(species,level,player=nil,withMoves=true)
     ospecies = species.to_s
     species = getID(PBSpecies,species)
     cname = getConstantName(PBSpecies,species) rescue nil
-    realSpecies = pbGetSpeciesFromFSpecies(species)[0] if species && species>0
-    if !species || species<=0 || realSpecies>PBSpecies.maxValue || !cname
+    realSpecies = pbGetSpeciesFromFSpecies(species)[0] if species && species > 0
+    if !species || species<=0 || realSpecies > PBSpecies.maxValue || !cname
       raise ArgumentError.new(_INTL("The species given ({1}) is invalid.",ospecies))
     end
     @species      = realSpecies
@@ -1018,8 +1052,7 @@ class PokeBattle_Pokemon
   end
 end
 
-
-
+# (see PokeBattle_Pokemon#initialize)
 def pbNewPkmn(species,level,owner=nil,withMoves=true)
   owner = $Trainer if !owner
   return PokeBattle_Pokemon.new(species,level,owner,withMoves)

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -1,9 +1,9 @@
 # This class stores data on each Pokémon. Refer to $Trainer.party for an array
 # of each Pokémon in the Trainer's current party.
 class PokeBattle_Pokemon
-  # @return [String] the nickname
+  # @return [String] the nickname of this Pokémon
   attr_accessor :name
-  # @return [Integer] the national Pokédex number
+  # @return [Integer] this Pokémon's national Pokédex number
   attr_reader   :species
   # @return [Integer] the current experience points
   attr_reader   :exp
@@ -724,9 +724,10 @@ class PokeBattle_Pokemon
     return held_item == getID(PBItems,item_id)
   end
 
-  # @param item_id [Integer, Symbol, String] id of the item to give to this Pokémon
+  # Gives an item to this Pokémon. Passing 0 as the argument removes the held item.
+  # @param item_id [Integer, Symbol, String] id of the item to give to this Pokémon (0 removes held item)
   def setItem(item_id)
-    self.item = getID(PBItems,item_id)
+    self.item = item_id.is_a?(Integer) ? item_id : getID(PBItems,item_id)
   end
 
   # @return [Array<Integer>] the items this species can be found holding in the wild
@@ -745,6 +746,8 @@ class PokeBattle_Pokemon
     return @mail
   end
 
+  # If mail is a PokemonMail object, gives that mail to this Pokémon. If nil is given,
+  # removes the held mail.
   # @param mail [PokemonMail, nil] mail to be held by this Pokémon (nil if mail is to be removed)
   def mail=(mail)
     if !mail.nil? && !mail.is_a?(PokemonMail)
@@ -1038,6 +1041,7 @@ class PokeBattle_Pokemon
     @speed   = stats[PBStats::SPEED]
   end
 
+  # Creates a copy of this Pokémon and returns it.
   # @return [PokeBattle_Pokemon] a copy of this Pokémon
   def clone
     ret = super

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -31,15 +31,20 @@ class PokeBattle_Pokemon
   attr_accessor :genderflag
   # @return [Integer] forces a particular nature (nature ID)
   attr_accessor :natureflag
-  attr_accessor :natureOverride   # Overrides nature's stat-changing effects
-  attr_accessor :shinyflag   # Forces the shininess (true/false)
-  attr_accessor :moves       # Moves (PBMove)
-  attr_accessor :firstmoves  # The moves known when this Pokémon was obtained
-  attr_accessor :item        # Held item
-  attr_writer   :mail        # Mail
-  attr_accessor :fused       # The Pokémon fused into this one
-  attr_accessor :iv          # Array of 6 Individual Values for HP, Atk, Def,
-                             #    Speed, Sp Atk, and Sp Def
+  # @return [Integer] overrides nature's stat-changing effects
+  attr_accessor :natureOverride
+  # @return [Boolean] whether shininess should be forced
+  attr_accessor :shinyflag
+  # @return [Array<PBMove>] moves known by this Pokémon
+  attr_accessor :moves
+  # @return [Array<Integer>] IDs of moves known by this Pokémon when it was obtained
+  attr_accessor :firstmoves
+  # @return [Integer] id of the item held by this Pokémon (0 = no held item)
+  attr_accessor :item
+  # @return [PokeBattle_Pokemon, nil] the Pokémon fused into this one (nil if there is none)
+  attr_accessor :fused
+  # @return [Array<Integer>] array of IV values for HP, Atk, Def, Speed, Sp. Atk and Sp. Def
+  attr_accessor :iv
   attr_writer   :ivMaxed     # Array of booleans that max each IV value
   attr_accessor :ev          # Effort Values
   attr_accessor :happiness   # Current happiness
@@ -663,11 +668,19 @@ class PokeBattle_Pokemon
     return ret
   end
 
-  # Returns this Pokémon's mail.
+  # @return [PokemonMail, nil] mail held by this Pokémon (nil if there is none)
   def mail
     return nil if !@mail
     @mail = nil if @mail.item==0 || !hasItem?(@mail.item)
     return @mail
+  end
+
+  # @param mail [PokemonMail, nil] mail to be held by this Pokémon (nil if mail is to be removed)
+  def mail=(mail)
+    if !mail.nil? && !mail.is_a?(PokemonMail)
+      raise ArgumentError, _INTL('Invalid value {1} given',mail.inspect)
+    end
+    @mail = mail
   end
 
   #=============================================================================

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -1,25 +1,25 @@
 # This class stores data on each Pokémon. Refer to $Trainer.party for an array
 # of each Pokémon in the Trainer's current party.
 class PokeBattle_Pokemon
-  # @return [String] nickname
+  # @return [String] the nickname
   attr_accessor :name
-  # @return [Integer] national Pokédex number
+  # @return [Integer] the national Pokédex number
   attr_reader   :species
-  # @return [Integer] current experience points
+  # @return [Integer] the current experience points
   attr_reader   :exp
-  # @return [Integer] current HP
+  # @return [Integer] the current HP
   attr_reader   :hp
-  # @return [Integer] current Total HP
+  # @return [Integer] the current Total HP
   attr_reader   :totalhp
-  # @return [Integer] current Attack stat
+  # @return [Integer] the current Attack stat
   attr_reader   :attack
-  # @return [Integer] current Defense stat
+  # @return [Integer] the current Defense stat
   attr_reader   :defense
-  # @return [Integer] current Speed stat
+  # @return [Integer] the current Speed stat
   attr_reader   :speed
-  # @return [Integer] current Special Attack stat
+  # @return [Integer] the current Special Attack stat
   attr_reader   :spatk
-  # @return [Integer] current Special Defense stat
+  # @return [Integer] the current Special Defense stat
   attr_reader   :spdef
   # If defined, forces the Pokémon's ability to be the first natural (0),
   # second natural (1) or hidden (2) ability available to its species.
@@ -28,79 +28,105 @@ class PokeBattle_Pokemon
   # (or "pokemonforms.txt" for its species and form). 
   # @return [0, 1, 2, nil] forced ability index (nil if none is set)
   attr_accessor :abilityflag
-  # @return [0, 1, nil] if defined, forces male (0) or female (1)
+  # If defined, forces this Pokémon to be male (0) or female (1).
+  # @return [0, 1, nil] gender to force: male (0) or female (1) (nil if undefined)
   attr_accessor :genderflag
-  # @return [Integer] forces a particular nature (nature ID)
+  # If defined, forces this Pokémon to have a particular nature.
+  # @return [Integer, nil] ID of the nature to force (nil if undefined)
   attr_accessor :natureflag
-  # @return [Integer] overrides nature's stat-changing effects
+  # If defined, overrides this Pokémon's nature's stat-changing effects.
+  # @return [Integer, nil] overridden nature stat-changing effects (nil if undefined)
   attr_accessor :natureOverride
   # If defined, forces the Pokémon to be shiny (true) or not (false).
   # @return [Boolean, nil] whether shininess should be forced (nil if undefined)
   attr_accessor :shinyflag
-  # @return [Array<PBMove>] moves known by this Pokémon
+  # @return [Array<PBMove>] the moves known by this Pokémon
   attr_accessor :moves
-  # @return [Array<Integer>] IDs of moves known by this Pokémon when it was obtained
+  # @return [Array<Integer>] the IDs of moves known by this Pokémon when it was obtained
   attr_accessor :firstmoves
-  # @return [Integer] id of the item held by this Pokémon (0 = no held item)
+  # @return [Integer] the ID of the item held by this Pokémon (0 = no held item)
   attr_accessor :item
   # Another Pokémon which has been fused with this Pokémon (or nil if there is none).
   # Currently only used by Kyurem, to record a fused Reshiram or Zekrom.  
   # @return [PokeBattle_Pokemon, nil] the Pokémon fused into this one (nil if there is none)
   attr_accessor :fused
-  # @return [Array<Integer>] array of IV values for HP, Atk, Def, Speed, Sp. Atk and Sp. Def
+  # @return [Array<Integer>] an array of IV values for HP, Atk, Def, Speed, Sp. Atk and Sp. Def
   attr_accessor :iv
-  # @param value [Array<Boolean>] array of booleans that max each IV value
+  # @param value [Array<Boolean>] an array of booleans that max each IV value
   attr_writer   :ivMaxed
   # @return [Array<Integer>] this Pokémon's effort values
   attr_accessor :ev
   # @return [Integer] this Pokémon's current happiness (an integer between 0 and 255)
-  attr_accessor :happiness   # Current happiness
+  attr_accessor :happiness
   # @return [Integer] the type of ball used (refer to {$BallTypes} for valid types)
   attr_accessor :ballused
-  attr_accessor :eggsteps    # Steps to hatch egg, 0 if Pokémon is not an egg
-  attr_writer   :markings    # Markings
-  attr_accessor :ribbons     # Array of ribbons
-  attr_accessor :pokerus     # Pokérus strain and infection time
-  attr_accessor :personalID  # Personal ID
-  attr_accessor :trainerID   # 32-bit Trainer ID (the secret ID is in the upper
-                             #    16 bits)
-  attr_accessor :obtainMode  # Manner obtained:
-                             #    0 - met, 1 - as egg, 2 - traded,
-                             #    4 - fateful encounter
-  attr_accessor :obtainMap   # Map where obtained
-  attr_accessor :obtainText  # Replaces the obtain map's name if not nil
-  attr_writer   :obtainLevel # Level obtained
-  attr_accessor :hatchedMap  # Map where an egg was hatched
-  attr_writer   :language    # Language
-  attr_accessor :ot          # Original Trainer's name
-  attr_writer   :otgender    # Original Trainer's gender:
-                             #    0 - male, 1 - female, 2 - mixed, 3 - unknown
-                             #    For information only, not used to verify
-                             #    ownership of the Pokémon
-  attr_writer   :cool,:beauty,:cute,:smart,:tough,:sheen   # Contest stats
+  # @return [Integer] the number of steps until the egg hatches, 0 if Pokémon is not an egg
+  attr_accessor :eggsteps
+  # @param value [Integer] new markings for this Pokémon
+  attr_writer   :markings
+  # @return [Array<Integer>] an array of ribbons owned by this Pokémon
+  attr_accessor :ribbons
+  # @return [Integer] the Pokérus strain and infection time
+  attr_accessor :pokerus
+  # @return [Integer] this Pokémon's personal ID
+  attr_accessor :personalID
+  # The 32-bit ID of this Pokémon's trainer. The secret ID is in the
+  # upper 16 bits.
+  # @return [Integer] the ID of this Pokémon's trainer
+  attr_accessor :trainerID
+  # @return [Integer] the manner this Pokémon was obtained:
+  #   0 (met), 1 (as egg), 2 (traded), 4 (fateful encounter)
+  attr_accessor :obtainMode
+  # @return [Integer] the ID of the map this Pokémon was obtained in
+  attr_accessor :obtainMap
+  # Describes the manner this Pokémon was obtained. If left undefined,
+  # the obtain map's name is used.
+  # @return [String] the obtain text
+  attr_accessor :obtainText
+  # @param value [Integer] new obtain level
+  attr_writer   :obtainLevel
+  # If this Pokémon hatched from an egg, returns the map ID where the hatching happened.
+  # Otherwise returns 0.
+  # @return [Integer] the map ID where egg was hatched (0 by default)
+  attr_accessor :hatchedMap
+  # @param value [Integer] new language 
+  attr_writer   :language
+  # @return [String] the name of the original trainer
+  attr_accessor :ot
+  # Changes the gender of the original trainer. This is for information only,
+  # and is not used to verify ownership of the Pokémon.
+  # @param value [Integer] new value for the original trainer's gender:
+  #   0 - male, 1 - female, 2 - mixed, 3 - unknown
+  attr_writer   :otgender
+  # @param value [Integer] new contest stat
+  attr_writer   :cool,:beauty,:cute,:smart,:tough,:sheen
 
-  IV_STAT_LIMIT         = 31    # Max total IVs
-  EV_LIMIT              = 510   # Max total EVs
-  EV_STAT_LIMIT         = 252   # Max EVs that a single stat can have
-  MAX_POKEMON_NAME_SIZE = 10    # Maximum length a Pokémon's nickname can be
+  # Max total IVs
+  IV_STAT_LIMIT         = 31
+  # Max total EVs
+  EV_LIMIT              = 510
+  # Max EVs that a single stat can have
+  EV_STAT_LIMIT         = 252
+  # Maximum length a Pokémon's nickname can be
+  MAX_POKEMON_NAME_SIZE = 10
 
   #=============================================================================
   # Ownership, obtained information
   #=============================================================================
 
-  # @return [Integer] public portion of the original trainer's ID
+  # @return [Integer] the public portion of the original trainer's ID
   def publicID
     return @trainerID & 0xFFFF
   end
 
   # @param trainer [PokeBattle_Trainer] the trainer to compare to the OT
-  # @return [Boolean] whether the trainer and OT don't match
+  # @return [Boolean] whether the given trainer and this Pokémon's original trainer don't match
   def foreign?(trainer)
     return @trainerID != trainer.id || @ot != trainer.name
   end
   alias isForeign? foreign?
 
-  # @return [0, 1, 2] gender of this Pokémon original trainer (0 = male, 1 = female, 2 = unknown)
+  # @return [0, 1, 2] the gender of this Pokémon original trainer (0 = male, 1 = female, 2 = unknown)
   def otgender
     return @otgender || 2
   end
@@ -110,7 +136,7 @@ class PokeBattle_Pokemon
     return @obtainLevel || 0
   end
 
-  # @return [Time] time when this Pokémon was obtained
+  # @return [Time] the time when this Pokémon was obtained
   def timeReceived
     return @timeReceived ? Time.at(@timeReceived) : Time.gm(2000)
   end
@@ -121,7 +147,7 @@ class PokeBattle_Pokemon
     @timeReceived = value.to_i
   end
 
-  # @return [Time] time when this Pokémon hatched
+  # @return [Time] the time when this Pokémon hatched
   def timeEggHatched
     if obtainMode==1
       return @timeEggHatched ? Time.at(@timeEggHatched) : Time.gm(2000)
@@ -146,7 +172,8 @@ class PokeBattle_Pokemon
     return @level
   end
 
-  # Sets this Pokémon's level.
+  # Sets this Pokémon's level. The given level must be between 1 and the
+  # maximum level (defined in {PBExperience}).
   # @param value [Integer] new level (between 1 and the maximum level)
   def level=(value)
     if value < 1 || value > PBExperience.maxLevel
@@ -179,7 +206,7 @@ class PokeBattle_Pokemon
     return pbGetSpeciesData(@species,formSimple,SpeciesBaseExp)
   end
 
-  # @return [Float] number between 0 and 1 indicating how much of the current level's
+  # @return [Float] a number between 0 and 1 indicating how much of the current level's
   #   Exp this Pokémon has
   def expFraction
     l = self.level
@@ -303,18 +330,19 @@ class PokeBattle_Pokemon
     return abil!=nil && abil>=2
   end
 
-  # @return [Array<Array<Integer>>] the list of abilities this Pokémon can have
+  # @return [Array<Array<Integer>>] the list of abilities this Pokémon can have,
+  #   where every element is [ability ID,ability index]
   def getAbilityList
     ret = []
     abilities = pbGetSpeciesData(@species,formSimple,SpeciesAbilities)
     if abilities.is_a?(Array)
-      abilities.each_with_index { |a,i| ret.push([a,i]) if a && a>0 }
+      abilities.each_with_index { |a,i| ret.push([a,i]) if a && a > 0 }
     else
       ret.push([abilities,0]) if abilities>0
     end
     hiddenAbil = pbGetSpeciesData(@species,formSimple,SpeciesHiddenAbility)
     if hiddenAbil.is_a?(Array)
-      hiddenAbil.each_with_index { |a,i| ret.push([a,i+2]) if a && a>0 }
+      hiddenAbil.each_with_index { |a,i| ret.push([a,i+2]) if a && a > 0 }
     else
       ret.push([hiddenAbil,2]) if hiddenAbil>0
     end
@@ -327,12 +355,12 @@ class PokeBattle_Pokemon
 
   # @return [Integer] the ID of this Pokémon's nature
   def nature
-    return @natureflag || (@personalID%25)
+    return @natureflag || (@personalID % 25)
   end
 
   # Returns the calculated nature, taking into account things that change its
   # stat-altering effect (i.e. Gen 8 mints). Only used for calculating stats.
-  # @return [Integer] calculated nature
+  # @return [Integer] this Pokémon's calculated nature
   def calcNature
     return @natureOverride if @natureOverride
     return self.nature
@@ -350,7 +378,7 @@ class PokeBattle_Pokemon
   end
 
   # Sets this Pokémon's nature to a particular nature.
-  # @param value [Integer] nature to change to
+  # @param value [Integer, String, Symbol] nature to change to
   def setNature(value)
     @natureflag = getID(PBNatures,value)
     calcStats
@@ -387,14 +415,14 @@ class PokeBattle_Pokemon
 
   # @return [Integer] the Pokérus infection stage for this Pokémon
   def pokerusStrain
-    return @pokerus/16
+    return @pokerus / 16
   end
 
-  # Returns the Pokérus infection stage for this Pokémon.
-  # @return [0, 1, 2] Pokérus infection stage
-  #   (0 = not infected, 1 = infected, 2 = cured)
+  # Returns the Pokérus infection stage for this Pokémon. The possible stages are
+  # 0 (not infected), 1 (infected) and 2 (cured)
+  # @return [0, 1, 2] current Pokérus infection stage
   def pokerusStage
-    return 0 if !@pokerus || @pokerus==0
+    return 0 if !@pokerus || @pokerus == 0
     return 2 if @pokerus > 0 && (@pokerus % 16) == 0
     return 1
   end
@@ -470,7 +498,7 @@ class PokeBattle_Pokemon
     return ret
   end
 
-  # @param move [Integer, Symbol, String] id of the move to check
+  # @param move [Integer, Symbol, String] ID of the move to check
   # @return [Boolean] whether the Pokémon knows the given move
   def hasMove?(move)
     move = getID(PBMoves,move)
@@ -481,7 +509,7 @@ class PokeBattle_Pokemon
   alias knowsMove? hasMove?
 
   # Returns the list of moves this Pokémon can learn by levelling up.
-  # @return [Array<Array<Integer>>] move list, where every element is [level, move id]
+  # @return [Array<Array<Integer>>] this Pokémon's move list, where every element is [level, move ID]
   def getMoveList
     return pbGetSpeciesMoveset(@species,formSimple)
   end
@@ -506,7 +534,7 @@ class PokeBattle_Pokemon
   end
 
   # Silently learns the given move. Will erase the first known move if it has to.
-  # @param move [Integer, Symbol, String] id of the move to learn
+  # @param move [Integer, Symbol, String] ID of the move to learn
   def pbLearnMove(move)
     move = getID(PBMoves,move)
     return if move <= 0
@@ -535,7 +563,7 @@ class PokeBattle_Pokemon
   end
 
   # Deletes the given move from the Pokémon.
-  # @param move [Integer, Symbol, String] id of the move to delete
+  # @param move [Integer, Symbol, String] ID of the move to delete
   def pbDeleteMove(move)
     move = getID(PBMoves,move)
     return if !move || move<=0
@@ -571,14 +599,15 @@ class PokeBattle_Pokemon
     @moves.each { |m| @firstmoves.push(m.id) if m && m.id > 0 }
   end
 
-  # TODO Figure out better documentation for these first move methods
-  # @param move [Integer, Symbol, String] id of the move to add
+  # Adds a move to this Pokémon's first moves.
+  # @param move [Integer, Symbol, String] ID of the move to add
   def pbAddFirstMove(move)
     move = getID(PBMoves,move)
     @firstmoves.push(move) if move > 0 && !@firstmoves.include?(move)
   end
 
-  # @param move [Integer, Symbol, String] id of the move to remove
+  # Removes a move from this Pokémon's first moves.
+  # @param move [Integer, Symbol, String] ID of the move to remove
   def pbRemoveFirstMove(move)
     move = getID(PBMoves,move)
     @firstmoves.delete(move) if move > 0
@@ -589,8 +618,8 @@ class PokeBattle_Pokemon
     @firstmoves = []
   end
 
-  # @param move [Integer, Symbol, String] id of the move to check
-  # @return [Boolean] whether the Pokémon is compatible with the move
+  # @param move [Integer, Symbol, String] ID of the move to check
+  # @return [Boolean] whether the Pokémon is compatible with the given move
   def compatibleWithMove?(move)
     return pbSpeciesCompatible?(self.fSpecies,move)
   end
@@ -622,7 +651,7 @@ class PokeBattle_Pokemon
     return (@ribbons) ? @ribbons.length : 0
   end
 
-  # @param ribbon [Integer, Symbol, String] ribbon id to check
+  # @param ribbon [Integer, Symbol, String] ribbon ID to check
   # @return [Boolean] whether this Pokémon has the specified ribbon
   def hasRibbon?(ribbon)
     return false if !@ribbons
@@ -631,7 +660,8 @@ class PokeBattle_Pokemon
     return @ribbons.include?(ribbon)
   end
 
-  # @param ribbon [Integer, Symbol, String] id of the ribbon to give
+  # Gives a ribbon to this Pokémon.
+  # @param ribbon [Integer, Symbol, String] ID of the ribbon to give
   def giveRibbon(ribbon)
     @ribbons = [] if !@ribbons
     ribbon = getID(PBRibbons,ribbon)
@@ -639,7 +669,6 @@ class PokeBattle_Pokemon
     @ribbons.push(ribbon) if !@ribbons.include?(ribbon)
   end
 
-  # TODO Figure out a good way to document this
   # Replaces one ribbon with the next one along, if possible.
   def upgradeRibbon(*arg)
     @ribbons = [] if !@ribbons
@@ -661,6 +690,7 @@ class PokeBattle_Pokemon
     return 0
   end
 
+  # Removes the specified ribbon from this Pokémon.
   # @param ribbon [Integer, Symbol, String] id of the ribbon to remove
   def takeRibbon(ribbon)
     return if !@ribbons
@@ -750,13 +780,13 @@ class PokeBattle_Pokemon
   # Is 0, except if the Pokémon is:
   #
   # - Asleep: Is the number of rounds the Pokémon will remain asleep.
-  # This number is set when the Pokémon is made to fall asleep.
+  #   This number is set when the Pokémon is made to fall asleep.
   #
   # - Badly poisoned: If the Pokémon is Poisoned and this is "1", the
-  # Pokémon is badly poisoned instead (which affects how much poison
-  # damage it takes in battle). When the Pokémon leaves battle while
-  # badly poisoned, this value is set to 0 and it becomes regular Poisoned
-  # (even in later battles).
+  #   Pokémon is badly poisoned instead (which affects how much poison
+  #   damage it takes in battle). When the Pokémon leaves battle while
+  #   badly poisoned, this value is set to 0 and it becomes regular Poisoned
+  #   (even in later battles).
   # @return [Integer] sleep count / toxic flag
   def statusCount
     return @statusCount
@@ -857,13 +887,12 @@ class PokeBattle_Pokemon
     return "ABCDEFGHIJKLMNOPQRSTUVWXYZ?!"[@form,1]
   end
 
-  # TODO Check whether #height and #weight always return an integer
-  # Returns the height of this Pokémon.
+  # @return [Integer] the height of this Pokémon in decimetres (0.1 metres)
   def height
     return pbGetSpeciesData(@species,formSimple,SpeciesHeight)
   end
 
-  # Returns the weight of this Pokémon.
+  # @return [Integer] the weight of this Pokémon in hectograms (0.1 grams)
   def weight
     return pbGetSpeciesData(@species,formSimple,SpeciesWeight)
   end

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -274,7 +274,7 @@ class PokeBattle_Pokemon
 
   # Returns whether this Pokémon has a particular ability. If no value
   # is given, returns whether this Pokémon has an ability set.
-  # @param ability [Integer] ability ID to check  
+  # @param ability [Integer] ability ID to check
   # @return [Boolean] whether this Pokémon has a particular ability or
   #   an ability at all
   def hasAbility?(ability = 0)
@@ -332,7 +332,7 @@ class PokeBattle_Pokemon
 
   # Returns whether this Pokémon has a particular nature. If no value
   # is given, returns whether this Pokémon has a nature set.
-  # @param nature [Integer] nature ID to check  
+  # @param nature [Integer] nature ID to check
   # @return [Boolean] whether this Pokémon has a particular nature or
   #   a nature at all
   def hasNature?(nature = -1)
@@ -396,7 +396,7 @@ class PokeBattle_Pokemon
   def givePokerus(strain = 0)
     return if self.pokerusStage == 2   # Can't re-infect a cured Pokémon
     strain = 1 + rand(15) if strain <= 0 || strain >= 16
-    time = 1 + (strain %4 )
+    time = 1 + (strain % 4)
     @pokerus = time
     @pokerus |= strain << 4
   end

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -1,21 +1,36 @@
 # This class stores data on each Pokémon. Refer to $Trainer.party for an array
 # of each Pokémon in the Trainer's current party.
 class PokeBattle_Pokemon
-  attr_accessor :name        # Nickname
-  attr_reader   :species     # Species (National Pokedex number)
-  attr_reader   :exp         # Current experience points
-  attr_reader   :hp          # Current HP
-  attr_reader   :totalhp     # Current Total HP
-  attr_reader   :attack      # Current Attack stat
-  attr_reader   :defense     # Current Defense stat
-  attr_reader   :speed       # Current Speed stat
-  attr_reader   :spatk       # Current Special Attack stat
-  attr_reader   :spdef       # Current Special Defense stat
-  attr_accessor :status      # Status problem (PBStatuses)
-  attr_accessor :statusCount # Sleep count/Toxic flag
-  attr_accessor :abilityflag # Forces the first/second/hidden (0/1/2) ability
-  attr_accessor :genderflag  # Forces male (0) or female (1)
-  attr_accessor :natureflag  # Forces a particular nature
+  # @return [String] nickname
+  attr_accessor :name
+  # @return [Integer] national Pokédex number
+  attr_reader   :species
+  # @return [Integer] current experience points
+  attr_reader   :exp
+  # @return [Integer] current HP
+  attr_reader   :hp
+  # @return [Integer] current Total HP
+  attr_reader   :totalhp
+  # @return [Integer] current Attack stat
+  attr_reader   :attack
+  # @return [Integer] current Defense stat
+  attr_reader   :defense
+  # @return [Integer] current Speed stat
+  attr_reader   :speed
+  # @return [Integer] current Special Attack stat
+  attr_reader   :spatk
+  # @return [Integer] current Special Defense stat
+  attr_reader   :spdef
+  # @return [Integer] status problem (from PBStatus)
+  attr_accessor :status
+  # @return [Integer] sleep count / toxic flag
+  attr_accessor :statusCount
+  # @return [0, 1, 2] forces the first / second / hidden ability
+  attr_accessor :abilityflag
+  # @return [0, 1] forces male (0) or female (1)
+  attr_accessor :genderflag
+  # @return [Integer] forces a particular nature (nature ID)
+  attr_accessor :natureflag
   attr_accessor :natureOverride   # Overrides nature's stat-changing effects
   attr_accessor :shinyflag   # Forces the shininess (true/false)
   attr_accessor :moves       # Moves (PBMove)
@@ -59,38 +74,41 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Ownership, obtained information
   #=============================================================================
-  # Returns the public portion of the original trainer's ID.
+
+  # @return [Integer] public portion of the original trainer's ID
   def publicID
-    return @trainerID&0xFFFF
+    return @trainerID & 0xFFFF
   end
 
-  # Returns whether the specified Trainer is NOT this Pokémon's original trainer.
+  # @param trainer [PokeBattle_Trainer] the trainer to compare to the OT
+  # @return [Boolean] whether the trainer and OT don't match
   def foreign?(trainer)
-    return @trainerID!=trainer.id || @ot!=trainer.name
+    return @trainerID != trainer.id || @ot != trainer.name
   end
   alias isForeign? foreign?
 
-  # Returns the gender of this Pokémon's original trainer (2=unknown).
+  # @return [0, 1, 2] gender of this Pokémon original trainer (0 = male, 1 = female, 2 = unknown)
   def otgender
     return @otgender || 2
   end
 
-  # Returns this Pokémon's level when this Pokémon was obtained.
+  # @return [Integer] this Pokémon's level when it was obtained
   def obtainLevel
     return @obtainLevel || 0
   end
 
-  # Returns the time when this Pokémon was obtained.
+  # @return [Time] time when this Pokémon was obtained
   def timeReceived
     return @timeReceived ? Time.at(@timeReceived) : Time.gm(2000)
   end
 
-  # Sets the time when this Pokémon was obtained (in seconds since Unix epoch).
+  # Sets the time when this Pokémon was obtained.
+  # @param value [Integer, Time, #to_i] time in seconds since Unix epoch
   def timeReceived=(value)
     @timeReceived = value.to_i
   end
 
-  # Returns the time when this Pokémon hatched.
+  # @return [Time] time when this Pokémon hatched
   def timeEggHatched
     if obtainMode==1
       return @timeEggHatched ? Time.at(@timeEggHatched) : Time.gm(2000)
@@ -99,7 +117,8 @@ class PokeBattle_Pokemon
     end
   end
 
-  # Sets the time when this Pokémon hatched (in seconds since Unix epoch).
+  # Sets the time when this Pokémon hatched.
+  # @param value [Integer, Time, #to_i] time in seconds since Unix epoch
   def timeEggHatched=(value)
     @timeEggHatched = value.to_i
   end
@@ -107,13 +126,15 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Level
   #=============================================================================
-  # Returns this Pokémon's level.
+
+  # @return [Integer] this Pokémon's level
   def level
     @level = PBExperience.pbGetLevelFromExperience(@exp,self.growthrate) if !@level
     return @level
   end
 
   # Sets this Pokémon's level.
+  # @param value [Integer] new level (between 1 and the maximum level)
   def level=(value)
     if value<1 || value>PBExperience.maxLevel
       raise ArgumentError.new(_INTL("The level number ({1}) is invalid.",value))
@@ -123,42 +144,44 @@ class PokeBattle_Pokemon
   end
 
   # Sets this Pokémon's Exp. Points.
+  # @param value [Integer] new experience points
   def exp=(value)
     @exp = value
     @level = nil
   end
 
-  # Returns whether this Pokémon is an egg.
+  # @return [Boolean] whether this Pokémon is an egg
   def egg?
-    return @eggsteps>0
+    return @eggsteps > 0
   end
   alias isEgg? egg?
 
-  # Returns this Pokémon's growth rate.
+  # @return [Integer] this Pokémon's growth rate (from PBGrowthRates)
   def growthrate
     return pbGetSpeciesData(@species,formSimple,SpeciesGrowthRate)
   end
 
-  # Returns this Pokémon's base Experience value.
+  # @return [Integer] this Pokémon's base Experience value
   def baseExp
     return pbGetSpeciesData(@species,formSimple,SpeciesBaseExp)
   end
 
-  # Returns a number between 0 and 1 indicating how much of the current level's
-  # Exp this Pokémon has.
+  # @return [Float] number between 0 and 1 indicating how much of the current level's
+  #   Exp this Pokémon has
   def expFraction
     l = self.level
-    return 0.0 if l>=PBExperience.maxLevel
+    return 0.0 if l >= PBExperience.maxLevel
     gr = self.growthrate
-    startexp = PBExperience.pbGetStartExperience(l,gr)
-    endexp   = PBExperience.pbGetStartExperience(l+1,gr)
-    return 1.0*(@exp-startexp)/(endexp-startexp)
+    startexp = PBExperience.pbGetStartExperience(l, gr)
+    endexp   = PBExperience.pbGetStartExperience(l + 1, gr)
+    return 1.0 * (@exp - startexp) / (endexp - startexp)
   end
 
   #=============================================================================
   # Gender
   #=============================================================================
-  # Returns this Pokémon's gender. 0=male, 1=female, 2=genderless
+
+  # @return [0, 1, 2] this Pokémon's gender (0 = male, 1 = female, 2 = genderless)
   def gender
     # Return sole gender option for all male/all female/genderless species
     genderRate = pbGetSpeciesData(@species,formSimple,SpeciesGenderRate)
@@ -168,96 +191,106 @@ class PokeBattle_Pokemon
     when PBGenderRates::Genderless;   return 2
     end
     # Return gender for species that can be male or female
-    return @genderflag if @genderflag && (@genderflag==0 || @genderflag==1)
-    return ((@personalID&0xFF)<PBGenderRates.genderByte(genderRate)) ? 1 : 0
+    return @genderflag if @genderflag && (@genderflag == 0 || @genderflag == 1)
+    return ((@personalID & 0xFF) < PBGenderRates.genderByte(genderRate)) ? 1 : 0
   end
 
-  # Returns whether this Pokémon species is restricted to only ever being one
-  # gender (or genderless).
+  # @return [Boolean] whether this Pokémon species is restricted to only ever being one
+  #   gender (or genderless)
   def singleGendered?
     genderRate = pbGetSpeciesData(@species,formSimple,SpeciesGenderRate)
-    return genderRate==PBGenderRates::AlwaysMale ||
-           genderRate==PBGenderRates::AlwaysFemale ||
-           genderRate==PBGenderRates::Genderless
+    return genderRate == PBGenderRates::AlwaysMale ||
+           genderRate == PBGenderRates::AlwaysFemale ||
+           genderRate == PBGenderRates::Genderless
   end
   alias isSingleGendered? singleGendered?
 
-  # Returns whether this Pokémon is male.
+  # @return [Boolean] whether this Pokémon is male
   def male?
-    return self.gender==0
+    return self.gender == 0
   end
   alias isMale? male?
 
-  # Returns whether this Pokémon is female.
+  # @return [Boolean] whether this Pokémon is female
   def female?
-    return self.gender==1
+    return self.gender == 1
   end
   alias isFemale? female?
 
-  # Returns whether this Pokémon is genderless.
+  # @return [Boolean] whether this Pokémon is genderless
   def genderless?
-    return self.gender==2
+    return self.gender == 2
   end
   alias isGenderless? genderless?
 
   # Sets this Pokémon's gender to a particular gender (if possible).
+  # @param value [0, 1, 2] new gender (0 = male, 1 = female, 2 = genderless)
   def setGender(value)
     @genderflag = value if !singleGendered?
   end
 
+  # Makes this Pokémon male.
   def makeMale;   setGender(0); end
+  # Makes this Pokémon female.
   def makeFemale; setGender(1); end
 
   #=============================================================================
   # Ability
   #=============================================================================
-  # Returns the index of this Pokémon's ability.
+
+  # @return [Integer] the index of this Pokémon's ability
   def abilityIndex
-    return @abilityflag || (@personalID&1)
+    return @abilityflag || (@personalID & 1)
   end
 
-  # Returns the ID of this Pokémon's ability.
+  # @return [Integer] the ID of this Pokémon's ability
   def ability
     abilIndex = abilityIndex
     # Hidden ability
-    if abilIndex>=2
+    if abilIndex >= 2
       hiddenAbil = pbGetSpeciesData(@species,formSimple,SpeciesHiddenAbility)
       if hiddenAbil.is_a?(Array)
-        ret = hiddenAbil[abilIndex-2]
-        return ret if ret && ret>0
+        ret = hiddenAbil[abilIndex - 2]
+        return ret if ret && ret > 0
       else
-        return hiddenAbil if abilIndex==2 && hiddenAbil>0
+        return hiddenAbil if abilIndex == 2 && hiddenAbil > 0
       end
-      abilIndex = (@personalID&1)
+      abilIndex = (@personalID & 1)
     end
     # Natural ability
     abilities = pbGetSpeciesData(@species,formSimple,SpeciesAbilities)
     if abilities.is_a?(Array)
       ret = abilities[abilIndex]
-      ret = abilities[(abilIndex+1)%2] if !ret || ret==0
+      ret = abilities[(abilIndex + 1) % 2] if !ret || ret == 0
       return ret || 0
     end
     return abilities || 0
   end
 
-  # Returns whether this Pokémon has a particular ability.
-  def hasAbility?(value=0)
-    abil = self.ability
-    return abil>0 if value==0
-    return abil==getID(PBAbilities,value)
+  # Returns whether this Pokémon has a particular ability. If no value
+  # is given, returns whether this Pokémon has an ability set.
+  # @param ability [Integer] ability ID to check  
+  # @return [Boolean] whether this Pokémon has a particular ability or
+  #   an ability at all
+  def hasAbility?(ability = 0)
+    current_ability = self.ability
+    return current_ability > 0 if ability == 0
+    return current_ability == getID(PBAbilities,ability)
   end
 
-  # Sets this Pokémon's ability to a particular ability (if possible).
+  # Sets this Pokémon's ability index.
+  # @param value [Integer] new ability index
   def setAbility(value)
     @abilityflag = value
   end
 
+  # @return [Boolean] whether this Pokémon has a hidden ability
   def hasHiddenAbility?
     abil = abilityIndex
     return abil!=nil && abil>=2
   end
 
-  # Returns the list of abilities this Pokémon can have.
+  # @return [Array<Array<Integer>>] the list of abilities this Pokémon can have
   def getAbilityList
     ret = []
     abilities = pbGetSpeciesData(@species,formSimple,SpeciesAbilities)
@@ -278,26 +311,33 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Nature
   #=============================================================================
-  # Returns the ID of this Pokémon's nature.
+
+  # @return [Integer] the ID of this Pokémon's nature
   def nature
     return @natureflag || (@personalID%25)
   end
 
   # Returns the calculated nature, taking into account things that change its
   # stat-altering effect (i.e. Gen 8 mints). Only used for calculating stats.
+  # @return [Integer] calculated nature
   def calcNature
     return @natureOverride if @natureOverride
     return self.nature
   end
 
-  # Returns whether this Pokémon has a particular nature.
-  def hasNature?(value=-1)
-    nat = self.nature
-    return nat>=0 if value<0
-    return nat==getID(PBNatures,value)
+  # Returns whether this Pokémon has a particular nature. If no value
+  # is given, returns whether this Pokémon has a nature set.
+  # @param nature [Integer] nature ID to check  
+  # @return [Boolean] whether this Pokémon has a particular nature or
+  #   a nature at all
+  def hasNature?(nature = -1)
+    current_nature = self.nature
+    return current_nature >= 0 if nature < 0
+    return current_nature == getID(PBNatures,nature)
   end
 
   # Sets this Pokémon's nature to a particular nature.
+  # @param value [Integer] nature to change to
   def setNature(value)
     @natureflag = getID(PBNatures,value)
     calcStats
@@ -306,14 +346,15 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Shininess
   #=============================================================================
-  # Returns whether this Pokémon is shiny (differently colored).
+
+  # @return [Boolean] whether this Pokémon is shiny (differently colored)
   def shiny?
-    return @shinyflag if @shinyflag!=nil
-    a = @personalID^@trainerID
-    b = a&0xFFFF
-    c = (a>>16)&0xFFFF
-    d = b^c
-    return d<SHINY_POKEMON_CHANCE
+    return @shinyflag if @shinyflag != nil
+    a = @personalID ^ @trainerID
+    b = a & 0xFFFF
+    c = (a >> 16) & 0xFFFF
+    d = b ^ c
+    return d < SHINY_POKEMON_CHANCE
   end
   alias isShiny? shiny?
 
@@ -330,12 +371,15 @@ class PokeBattle_Pokemon
   #=============================================================================
   # Pokérus
   #=============================================================================
-  # Returns the Pokérus infection stage for this Pokémon.
+
+  # @return [Integer] the Pokérus infection stage for this Pokémon
   def pokerusStrain
     return @pokerus/16
   end
 
   # Returns the Pokérus infection stage for this Pokémon.
+  # @return [0, 1, 2] Pokérus infection stage
+  #   (0 = not infected, 1 = cured, 2 = infected)
   def pokerusStage
     return 0 if !@pokerus || @pokerus==0        # Not infected
     return 2 if @pokerus>0 && (@pokerus%16)==0  # Cured
@@ -343,32 +387,34 @@ class PokeBattle_Pokemon
   end
 
   # Gives this Pokémon Pokérus (either the specified strain or a random one).
-  def givePokerus(strain=0)
-    return if self.pokerusStage==2   # Can't re-infect a cured Pokémon
-    strain = 1+rand(15) if strain<=0 || strain>=16
-    time = 1+(strain%4)
+  # @param strain [Integer] Pokérus strain to give
+  def givePokerus(strain = 0)
+    return if self.pokerusStage == 2   # Can't re-infect a cured Pokémon
+    strain = 1 + rand(15) if strain <= 0 || strain >= 16
+    time = 1 + (strain %4 )
     @pokerus = time
     @pokerus |= strain << 4
   end
 
   # Resets the infection time for this Pokémon's Pokérus (even if cured).
   def resetPokerusTime
-    return if @pokerus==0
-    strain = @pokerus%16
-    time = 1+(strain%4)
+    return if @pokerus == 0
+    strain = @pokerus % 16
+    time = 1 + (strain % 4)
     @pokerus = time
     @pokerus |= strain << 4
   end
 
   # Reduces the time remaining for this Pokémon's Pokérus (if infected).
   def lowerPokerusCount
-    return if self.pokerusStage!=1
+    return if self.pokerusStage != 1
     @pokerus -= 1
   end
 
   #=============================================================================
   # Types
   #=============================================================================
+
   # Returns this Pokémon's first type.
   def type1
     return pbGetSpeciesData(@species,formSimple,SpeciesType1)

--- a/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
+++ b/Data/Scripts/016_Pokemon/001_PokeBattle_Pokemon.rb
@@ -22,10 +22,10 @@ class PokeBattle_Pokemon
   # @return [Integer] current Special Defense stat
   attr_reader   :spdef
   # If defined, forces the Pokémon's ability to be the first natural (0),
-  #   second natural (1) or hidden (2) ability available to its species.
-  #   It is not possible to give the Pokémon any ability other than those
-  #   defined in the PBS file "pokemon.txt" for its species
-  #   (or "pokemonforms.txt" for its species and form). 
+  # second natural (1) or hidden (2) ability available to its species.
+  # It is not possible to give the Pokémon any ability other than those
+  # defined in the PBS file "pokemon.txt" for its species
+  # (or "pokemonforms.txt" for its species and form). 
   # @return [0, 1, 2, nil] forced ability index (nil if none is set)
   attr_accessor :abilityflag
   # @return [0, 1, nil] if defined, forces male (0) or female (1)
@@ -43,17 +43,20 @@ class PokeBattle_Pokemon
   attr_accessor :firstmoves
   # @return [Integer] id of the item held by this Pokémon (0 = no held item)
   attr_accessor :item
-  # Another Pokémon which has been fused with this Pokémon (or ´nil´ if there is none).
-  #   Currently only used by Kyurem, to record a fused Reshiram or Zekrom.  
+  # Another Pokémon which has been fused with this Pokémon (or nil if there is none).
+  # Currently only used by Kyurem, to record a fused Reshiram or Zekrom.  
   # @return [PokeBattle_Pokemon, nil] the Pokémon fused into this one (nil if there is none)
   attr_accessor :fused
   # @return [Array<Integer>] array of IV values for HP, Atk, Def, Speed, Sp. Atk and Sp. Def
   attr_accessor :iv
-  # @return [Array<Boolean>] 
-  attr_writer   :ivMaxed     # Array of booleans that max each IV value
-  attr_accessor :ev          # Effort Values
+  # @param value [Array<Boolean>] array of booleans that max each IV value
+  attr_writer   :ivMaxed
+  # @return [Array<Integer>] this Pokémon's effort values
+  attr_accessor :ev
+  # @return [Integer] this Pokémon's current happiness (an integer between 0 and 255)
   attr_accessor :happiness   # Current happiness
-  attr_accessor :ballused    # Ball used
+  # @return [Integer] the type of ball used (refer to {$BallTypes} for valid types)
+  attr_accessor :ballused
   attr_accessor :eggsteps    # Steps to hatch egg, 0 if Pokémon is not an egg
   attr_writer   :markings    # Markings
   attr_accessor :ribbons     # Array of ribbons
@@ -724,11 +727,14 @@ class PokeBattle_Pokemon
   # Status
   #=============================================================================
 
+  # Returns the current status of this Pokémon. See {PBStatuses} for all possible
+  # status effects.
   # @return [Integer] current status (from PBStatuses)
   def status
     return @status
   end
 
+  # Sets this Pokémon's status. See {PBStatuses} for all possible status effects.
   # @param new_status [Integer, Symbol, String] status to set (from PBStatuses)
   def status=(new_status)
     if new_status.is_a?(Integer)
@@ -756,7 +762,7 @@ class PokeBattle_Pokemon
     return @statusCount
   end
 
-  # (see #statusCount)
+  # Sets a new status count. See {#statusCount} for more information.
   # @param new_status_count [Integer] new sleep count / toxic flag
   def statusCount=(new_status_count)
     @statusCount = new_status_count


### PR DESCRIPTION
I've done a number of changes in `016_Pokemon/PokeBattle_Pokemon.rb`:

- YARD-style documentation for every method and constant, seen [here](https://savordez.xyz/doctest/)
- Grouped methods related to status effects (`#status`, `#able?`, etc.) in a new "Status" section
- `#mail=` and `#statusCount=`  are no longer defined with `attr_writer`. They now validate their arguments.
- A couple of variables have been renamed to be more legible (`s` to `species`, `nat` to `current_nature`, etc.)

I believe there are too many methods defined with the `attr` methods in this class – I could give some of them the `#mail=` treatment.

I've made this a draft PR because the documentation isn't perfect yet. I feel like `#natureOverride` is a little confusing in particular, and the contest attribute writers aren't showing up in the documentation at all because they're all defined in a single `attr_writer` call.