### PR TITLE
Fix debug console not opening

### DIFF
--- a/Data/Scripts/001_Technical/006_DebugConsole.rb
+++ b/Data/Scripts/001_Technical/006_DebugConsole.rb
@@ -48,6 +48,7 @@ module Console
     @apiSetConsoleTitle              = Win32API.new("kernel32","SetConsoleTitle","p","s")
     access = (GENERIC_READ | GENERIC_WRITE)
     sharemode = (FILE_SHARE_READ | FILE_SHARE_WRITE)
+    AllocConsole()
     @bufferHandle = CreateConsoleScreenBuffer(access,sharemode,CONSOLE_TEXTMODE_BUFFER)
     f = File.open("Game.ini")
     lines = f.readlines()


### PR DESCRIPTION
Looks like an AllocConsole call was removed from ``Console.setup_console`` at some point. This PR restores it.