### PR TITLE
Fix crash of Game_Character#jumping? in old saves

### DIFF
--- a/Data/Scripts/003_Game classes/005_Game_Character.rb
+++ b/Data/Scripts/003_Game classes/005_Game_Character.rb
@@ -253,6 +253,7 @@ class Game_Character
   end
 
   def jumping?
+    @jump_distance_left ||= 0 # COMPATIBILITY: For save files created before v18.1
     return @jump_distance_left > 0
   end
 


### PR DESCRIPTION
``@jump_distance_left`` is undefined (nil) in old save files. This PR ensures that the value is 0 when read from in ``#jumping?``.