### PR TITLE
Edit order of commands in pbMessageDisplay to fix light text assignment

### DIFF
--- a/Data/Scripts/009_Objects and windows/011_Messages.rb
+++ b/Data/Scripts/009_Objects and windows/011_Messages.rb
@@ -1041,6 +1041,14 @@ def pbMessageDisplay(msgwindow,message,letterbyletter=true,commandProc=nil)
   text.gsub!(/\\pog/i,"")
   text.gsub!(/\\b/i,"<c3=3050C8,D0D0C8>")
   text.gsub!(/\\r/i,"<c3=E00808,D0D0C8>")
+  text.gsub!(/\\[Ww]\[([^\]]*)\]/) {
+    w = $1.to_s
+    if w==""
+      next msgwindow.windowskin = nil
+    else
+      next msgwindow.setSkin("Graphics/Windowskins/#{w}",false)
+    end
+  }
   isDarkSkin = isDarkWindowskin(msgwindow.windowskin)
   text.gsub!(/\\[Cc]\[([0-9]+)\]/) {
     m = $1.to_i
@@ -1071,7 +1079,7 @@ def pbMessageDisplay(msgwindow,message,letterbyletter=true,commandProc=nil)
   ### Controls
   textchunks=[]
   controls=[]
-  while text[/(?:\\(w|f|ff|ts|cl|me|se|wt|wtnp|ch)\[([^\]]*)\]|\\(g|cn|wd|wm|op|cl|wu|\.|\||\!|\^))/i]
+  while text[/(?:\\(f|ff|ts|cl|me|se|wt|wtnp|ch)\[([^\]]*)\]|\\(g|cn|wd|wm|op|cl|wu|\.|\||\!|\^))/i]
     textchunks.push($~.pre_match)
     if $~[1]
       controls.push([$~[1].downcase,$~[2],-1])
@@ -1206,12 +1214,6 @@ def pbMessageDisplay(msgwindow,message,letterbyletter=true,commandProc=nil)
         msgback.y = msgwindow.y if msgback
         pbPositionNearMsgWindow(facewindow,msgwindow,:left)
         msgwindow.y = Graphics.height-msgwindow.height*(signWaitTime-signWaitCount)/signWaitTime
-      when "w"      # Change windowskin
-        if param==""
-          msgwindow.windowskin = nil
-        else
-          msgwindow.setSkin("Graphics/Windowskins/#{param}",false)
-        end
       when "ts"     # Change text speed
         msgwindow.textspeed = (param=="") ? -999 : param.to_i
       when "."      # Wait 0.25 seconds

--- a/Data/Scripts/009_Objects and windows/011_Messages.rb
+++ b/Data/Scripts/009_Objects and windows/011_Messages.rb
@@ -1044,10 +1044,11 @@ def pbMessageDisplay(msgwindow,message,letterbyletter=true,commandProc=nil)
   text.gsub!(/\\[Ww]\[([^\]]*)\]/) {
     w = $1.to_s
     if w==""
-      next msgwindow.windowskin = nil
+      msgwindow.windowskin = nil
     else
-      next msgwindow.setSkin("Graphics/Windowskins/#{w}",false)
+      msgwindow.setSkin("Graphics/Windowskins/#{w}",false)
     end
+    next ""
   }
   isDarkSkin = isDarkWindowskin(msgwindow.windowskin)
   text.gsub!(/\\[Cc]\[([0-9]+)\]/) {


### PR DESCRIPTION
This fixes issue #39 

Fixes the issue changing windowskin assignment, removing it from the command loop, to before color assignment