### PR TITLE
Kernel.validate

### DIFF
--- a/Data/Scripts/001_Technical/010_Validation.rb
+++ b/Data/Scripts/001_Technical/010_Validation.rb
@@ -1,0 +1,22 @@
+# The Kernel module is extended to include the validate method.
+module Kernel
+  # Validates the given values. Takes a hash as its argument, e.g.:
+  # +value1 => Integer, value2 => String, value3 => [Rect,Viewport]+
+  # @param value_pairs [Hash] value pairs to validate
+  # @raise [TypeError] raised if validation fails
+  def validate(value_pairs)
+    unless value_pairs.instance_of?(Hash)
+      raise TypeError, _INTL("Non-hash argument #{value_pairs.inspect} passed into validate")
+    end
+    value_pairs.each do |value, type|
+      if type.is_a?(Array)
+        match = false
+        type.each { |c| match = true if value.is_a?(c) }
+        next if match
+      elsif value.is_a?(type)
+        next
+      end
+      raise TypeError, _INTL("#{value.class} value does not implement #{type.inspect}")
+    end
+  end
+end

--- a/Data/Scripts/001_Technical/010_Validation.rb
+++ b/Data/Scripts/001_Technical/010_Validation.rb
@@ -5,7 +5,7 @@ module Kernel
   # Used to check whether values are of a given class or respond to a method.
   # @param value_pairs [Hash{Object => Class, Array<Class>, Symbol}] value pairs to validate
   # @example Validate a class or method
-  #   validate foo => Integer, baz => :to_s # raises an error if foo is not an Integer or if baz doesn't implement .to_s
+  #   validate foo => Integer, baz => :to_s # raises an error if foo is not an Integer or if baz doesn't implement #to_s
   # @example Validate a class from an array
   #   validate foo => [Sprite, Bitmap, Viewport] # raises an error if foo isn't a Sprite, Bitmap or Viewport
   # @raise [ArgumentError] raised if validation fails

--- a/Data/Scripts/001_Technical/010_Validation.rb
+++ b/Data/Scripts/001_Technical/010_Validation.rb
@@ -11,7 +11,7 @@ module Kernel
   # @raise [ArgumentError] raised if validation fails
   def validate(value_pairs)
     unless value_pairs.is_a?(Hash)
-      raise ArgumentError, "Non-hash argument #{value_pairs.inspect} passed into validate"
+      raise ArgumentError, "Non-hash argument #{value_pairs.inspect} passed into validate."
     end
     errors = value_pairs.map do |value, condition|
       if condition.is_a?(Array)
@@ -19,13 +19,13 @@ module Kernel
           next "Expected #{value.inspect} to be one of #{condition.inspect}, but got #{value.class.name}."
         end
       elsif condition.is_a?(Symbol)
-        next "Expected #{value.inspect} to respond to .#{condition}." unless value.respond_to?(condition)
+        next "Expected #{value.inspect} to respond to #{condition}." unless value.respond_to?(condition)
       elsif !value.is_a?(condition)
         next "Expected #{value.inspect} to be a #{condition.name}, but got #{value.class.name}."
       end
     end
     errors.compact!
     return if errors.empty?
-    raise ArgumentError, "Invalid argument passed to method.\n\n" + errors.join("\n")
+    raise ArgumentError, "Invalid argument passed to method.\r\n" + errors.join("\r\n")
   end
 end


### PR DESCRIPTION
This PR implements the `validate` method in `Kernel`, allowing for easy validation of classes and methods:

```ruby
validate foo => Integer, bar => :to_s # raises an error if foo is not an Integer or if bar doesn't implement #to_s
validate baz => [Sprite, Bitmap, Viewport] # raises an error if baz isn't a Sprite, Bitmap or Viewport
```
```ruby
class PokeBattle_Trainer
  def money=(value)
    validate value => Integer
    @money = [[value, MAX_MONEY].min, 0].max
  end
end
```
The method is private, meaning that code like `5.validate` will result in an error.

The implementation is largely inspired by @Marin-MK's own [validate.rb](https://github.com/Marin-MK/MK-Starter-Kit/blob/master/scripts/core/utils/validate.rb#L13).