### PR TITLE
Gen8 milcery

### DIFF
--- a/Data/Scripts/016_Pokemon/002_Pokemon_Forms.rb
+++ b/Data/Scripts/016_Pokemon/002_Pokemon_Forms.rb
@@ -746,3 +746,13 @@ MultipleForms.register(:KOFFING,{
 })
 
 MultipleForms.copy(:KOFFING,:MIMEJR)
+
+
+#===============================================================================
+# Alcremie
+#===============================================================================
+MultipleForms.register(:ALCREMIE,{
+  "getFormOnCreation" => proc { |pkmn|
+    next rand(63)
+  }
+})

--- a/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
+++ b/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
@@ -63,8 +63,9 @@ module PBEvolution
   TradeSpecies      = 59
   CriticalHits      = 60
   DamageDone        = 61
+  ItemMilcery       = 62
 
-  def self.maxValue; return 61; end
+  def self.maxValue; return 62; end
 
   @@evolution_methods = HandlerHash.new(:PBEvolution)
 
@@ -777,5 +778,47 @@ PBEvolution.register(:CriticalHits, {
 PBEvolution.register(:DamageDone, {
   "onFieldCheck" => proc { |pkmn, parameter|
      next true if pkmn.yamaskhp >= parameter
+  }
+})
+
+
+
+#===============================================================================
+# Evolution of Milcery
+#===============================================================================
+
+PBEvolution.register(:ItemMilcery, {
+  "parameterType" => :PBItems,
+  "itemCheck"     => proc { |pkmn, parameter, item|
+		if item == parameter
+			cream = 0
+			cream = pkmn.level % 9  if !pkmn.isShiny? 
+			# Shiny only has one cream color per flavour.
+			# I didn't know how to handle the different cream flavours, so I decided 
+			# to link it to the level. 
+
+			case item
+			when PBItems::STRAWBERRYSWEET
+				sweet = 1
+			when PBItems::BERRYSWEET
+				sweet = 2
+			when PBItems::CLOVERSWEET
+				sweet = 3
+			when PBItems::FLOWERSWEET
+				sweet = 4
+			when PBItems::LOVESWEET
+				sweet = 5
+			when PBItems::RIBBONSWEET
+				sweet = 6
+			when PBItems::STARSWEET
+				sweet = 7
+			else 
+				sweet = 1
+			end 
+
+			pkmn.form= cream*7 + sweet 
+		end 
+	  
+    next item == parameter
   }
 })

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -27452,7 +27452,7 @@ BattlerEnemyX = 0
 BattlerEnemyY = 35
 BattlerShadowX = 0
 BattlerShadowSize = 2
-Evolutions = ALCREMIE,Item,STRAWBERRYSWEET
+Evolutions = ALCREMIE,ItemMilcery,BERRYSWEET,ALCREMIE,ItemMilcery,CLOVERSWEET,ALCREMIE,ItemMilcery,FLOWERSWEET,ALCREMIE,ItemMilcery,LOVESWEET,ALCREMIE,ItemMilcery,RIBBONSWEET,ALCREMIE,ItemMilcery,STARSWEET,ALCREMIE,ItemMilcery,STRAWBERRYSWEET
 #-------------------------------
 [869]
 Name = Alcremie

--- a/PBS/pokemonforms.txt
+++ b/PBS/pokemonforms.txt
@@ -2162,3 +2162,189 @@ Moves = 0,SURGINGSTRIKES,1,SURGINGSTRIKES,1,AQUAJET,1,ROCKSMASH,1,LEER,1,ENDURE,
 Pokedex = This form of Urshifu is a strong believer in defeating foes by raining many blows down on them. Its strikes are nonstop, flowing like a river.
 BattlerPlayerY = 8
 BattlerEnemyY = 12
+#-------------------------------
+[ALCREMIE,1]
+FormName = Strawberry - Ruby Cream
+#-------------------------------
+[ALCREMIE,2]
+FormName = Strawberry - Matcha Cream
+#-------------------------------
+[ALCREMIE,3]
+FormName = Strawberry - Mint Cream
+#-------------------------------
+[ALCREMIE,4]
+FormName = Strawberry - Lemon Cream
+#-------------------------------
+[ALCREMIE,5]
+FormName = Strawberry - Salted Cream
+#-------------------------------
+[ALCREMIE,6]
+FormName = Strawberry - Ruby Swirl
+#-------------------------------
+[ALCREMIE,7]
+FormName = Strawberry - Caramel Swirl
+#-------------------------------
+[ALCREMIE,8]
+FormName = Strawberry - Rainbow Swirl
+#-------------------------------
+[ALCREMIE,9]
+FormName = Berry - Vanilla Cream
+#-------------------------------
+[ALCREMIE,10]
+FormName = Berry - Ruby Cream
+#-------------------------------
+[ALCREMIE,11]
+FormName = Berry - Matcha Cream
+#-------------------------------
+[ALCREMIE,12]
+FormName = Berry - Mint Cream
+#-------------------------------
+[ALCREMIE,13]
+FormName = Berry - Lemon Cream
+#-------------------------------
+[ALCREMIE,14]
+FormName = Berry - Salted Cream
+#-------------------------------
+[ALCREMIE,15]
+FormName = Berry - Ruby Swirl
+#-------------------------------
+[ALCREMIE,16]
+FormName = Berry - Caramel Swirl
+#-------------------------------
+[ALCREMIE,17]
+FormName = Berry - Rainbow Swirl
+#-------------------------------
+[ALCREMIE,18]
+FormName = Clover - Vanilla Cream
+#-------------------------------
+[ALCREMIE,19]
+FormName = Clover - Ruby Cream
+#-------------------------------
+[ALCREMIE,20]
+FormName = Clover - Matcha Cream
+#-------------------------------
+[ALCREMIE,21]
+FormName = Clover - Mint Cream
+#-------------------------------
+[ALCREMIE,22]
+FormName = Clover - Lemon Cream
+#-------------------------------
+[ALCREMIE,23]
+FormName = Clover - Salted Cream
+#-------------------------------
+[ALCREMIE,24]
+FormName = Clover - Ruby Swirl
+#-------------------------------
+[ALCREMIE,25]
+FormName = Clover - Caramel Swirl
+#-------------------------------
+[ALCREMIE,26]
+FormName = Clover - Rainbow Swirl
+#-------------------------------
+[ALCREMIE,27]
+FormName = Flower - Vanilla Cream
+#-------------------------------
+[ALCREMIE,28]
+FormName = Flower - Ruby Cream
+#-------------------------------
+[ALCREMIE,29]
+FormName = Flower - Matcha Cream
+#-------------------------------
+[ALCREMIE,30]
+FormName = Flower - Mint Cream
+#-------------------------------
+[ALCREMIE,31]
+FormName = Flower - Lemon Cream
+#-------------------------------
+[ALCREMIE,32]
+FormName = Flower - Salted Cream
+#-------------------------------
+[ALCREMIE,33]
+FormName = Flower - Ruby Swirl
+#-------------------------------
+[ALCREMIE,34]
+FormName = Flower - Caramel Swirl
+#-------------------------------
+[ALCREMIE,35]
+FormName = Flower - Rainbow Swirl
+#-------------------------------
+[ALCREMIE,36]
+FormName = Love - Vanilla Cream
+#-------------------------------
+[ALCREMIE,37]
+FormName = Love - Ruby Cream
+#-------------------------------
+[ALCREMIE,38]
+FormName = Love - Matcha Cream
+#-------------------------------
+[ALCREMIE,39]
+FormName = Love - Mint Cream
+#-------------------------------
+[ALCREMIE,40]
+FormName = Love - Lemon Cream
+#-------------------------------
+[ALCREMIE,41]
+FormName = Love - Salted Cream
+#-------------------------------
+[ALCREMIE,42]
+FormName = Love - Ruby Swirl
+#-------------------------------
+[ALCREMIE,43]
+FormName = Love - Caramel Swirl
+#-------------------------------
+[ALCREMIE,44]
+FormName = Love - Rainbow Swirl
+#-------------------------------
+[ALCREMIE,45]
+FormName = Ribbon - Vanilla Cream
+#-------------------------------
+[ALCREMIE,46]
+FormName = Ribbon - Ruby Cream
+#-------------------------------
+[ALCREMIE,47]
+FormName = Ribbon - Matcha Cream
+#-------------------------------
+[ALCREMIE,48]
+FormName = Ribbon - Mint Cream
+#-------------------------------
+[ALCREMIE,49]
+FormName = Ribbon - Lemon Cream
+#-------------------------------
+[ALCREMIE,50]
+FormName = Ribbon - Salted Cream
+#-------------------------------
+[ALCREMIE,51]
+FormName = Ribbon - Ruby Swirl
+#-------------------------------
+[ALCREMIE,52]
+FormName = Ribbon - Caramel Swirl
+#-------------------------------
+[ALCREMIE,53]
+FormName = Ribbon - Rainbow Swirl
+#-------------------------------
+[ALCREMIE,54]
+FormName = Star - Vanilla Cream
+#-------------------------------
+[ALCREMIE,55]
+FormName = Star - Ruby Cream
+#-------------------------------
+[ALCREMIE,56]
+FormName = Star - Matcha Cream
+#-------------------------------
+[ALCREMIE,57]
+FormName = Star - Mint Cream
+#-------------------------------
+[ALCREMIE,58]
+FormName = Star - Lemon Cream
+#-------------------------------
+[ALCREMIE,59]
+FormName = Star - Salted Cream
+#-------------------------------
+[ALCREMIE,60]
+FormName = Star - Ruby Swirl
+#-------------------------------
+[ALCREMIE,61]
+FormName = Star - Caramel Swirl
+#-------------------------------
+[ALCREMIE,62]
+FormName = Star - Rainbow Swirl


### PR DESCRIPTION
Implementing Milcery's evolution.
Sweets are treated like evolution stones, except that using one of the sweets changes the form of Milcery right before evolving (hence a new "method" for evolving: ItemMilcery). As "dances" are not implemented, I replaced the nine "dances" with a simple computation of the level of Milcery (level modulo 9 is equivalent to one of the "dances"). 