### PR TITLE
Fix: EXP Full ding using wrong sound file

### DIFF
--- a/Data/Scripts/012_Battle/005_Battle scene/004_PokeBattle_SceneElements.rb
+++ b/Data/Scripts/012_Battle/005_Battle scene/004_PokeBattle_SceneElements.rb
@@ -326,7 +326,7 @@ class PokemonDataBox < SpriteWrapper
       if @expFlash==0
         pbSEStop
         @expFlash = Graphics.frame_rate/5
-        pbSEPlay("Exp full")
+        pbSEPlay("Pkmn exp full")
         self.flash(Color.new(64,200,248,192),@expFlash)
         for i in @sprites
           i[1].flash(Color.new(64,200,248,192),@expFlash) if !i[1].disposed?


### PR DESCRIPTION
Small typo in the Essentials vanilla code that makes the EXP Full sound not play when the EXP bar fills up