### PR TITLE
Fix for baby species to return the right species when checked with items

### DIFF
--- a/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
+++ b/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
@@ -157,7 +157,7 @@ def pbGetBabySpecies(species,item1=-1,item2=-1)
     next if !evo[3]
     if item1>=0 && item2>=0
       incense = pbGetSpeciesData(evo[0],0,SpeciesIncense)
-      ret = evo[0] if item1==incense || item2==incense || incense==0
+      ret = evo[0] if incense==0 || incense==item1 || incense==item2
     else
       ret = evo[0]   # Species of prevolution
     end

--- a/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
+++ b/Data/Scripts/016_Pokemon/005_Pokemon_Evolution.rb
@@ -157,13 +157,13 @@ def pbGetBabySpecies(species,item1=-1,item2=-1)
     next if !evo[3]
     if item1>=0 && item2>=0
       incense = pbGetSpeciesData(evo[0],0,SpeciesIncense)
-      ret = evo[0] if item1==incense || item2==incense
+      ret = evo[0] if item1==incense || item2==incense || incense==0
     else
       ret = evo[0]   # Species of prevolution
     end
     break
   end
-  ret = pbGetBabySpecies(ret) if ret!=species
+  ret = pbGetBabySpecies(ret,item1,item2) if ret!=species
   return ret
 end
 


### PR DESCRIPTION
This fixes a bug in the baby species determination when both parents are holding an item, creating an egg that's fully evolved
Also fixes a related bug, in which it doesn't check items when doing a recursive baby species check, effectively ignoring incense if it has to recurse before reaching the insense'd mon.

Easy test situation is with Roserade, as it can be used for both situations.
On a related note, this was also a bug in v17.2, and it was a similar fix as here.
https://pastebin.com/pJJjqs5r