### PR TITLE
Run Compiler before calling pbSetUpSystem

### DIFF
--- a/Data/Scripts/999_Main/999_Main.rb
+++ b/Data/Scripts/999_Main/999_Main.rb
@@ -1,5 +1,5 @@
-pbSetUpSystem
 Compiler.main
+pbSetUpSystem
 
 class Scene_DebugIntro
   def main


### PR DESCRIPTION
pbSetUpSystem will fail if the necessary .dat files do not exist. The compiler should run first to create them.