### PR TITLE
Remove SpriteWindowCursorRect & fix WindowCursorRect

### DIFF
--- a/Data/Scripts/009_Objects and windows/003_Window.rb
+++ b/Data/Scripts/009_Objects and windows/003_Window.rb
@@ -1,57 +1,53 @@
 class WindowCursorRect < Rect
   def initialize(window)
-    @window=window
-    @x=0
-    @y=0
-    @width=0
-    @height=0
+    super(0, 0, 0, 0)
+    @window = window
   end
 
-  attr_reader :x,:y,:width,:height
-
   def empty
-    needupdate=@x!=0 || @y!=0 || @width!=0 || @height!=0
-    if needupdate
-      @x=0
-      @y=0
-      @width=0
-      @height=0
-      @window.width=@window.width
-    end
+    return unless needs_update?
+
+    set(0, 0, 0, 0)
   end
 
   def isEmpty?
-    return @x==0 && @y==0 && @width==0 && @height==0
+    return self.x == 0 && self.y == 0 && self.width == 0 && self.height == 0
   end
 
-  def set(x,y,width,height)
-    needupdate=@x!=x || @y!=y || @width!=width || @height!=height
-    if needupdate
-      @x=x
-      @y=y
-      @width=width
-      @height=height
-      @window.width=@window.width
-    end
+  def set(x, y, width, height)
+    return unless needs_update?
+
+    super(x, y, width, height)
+
+    @window.width = @window.width
   end
 
   def height=(value)
-    @height=value; @window.width=@window.width
+    super(value)
+    @window.width = @window.width
   end
 
   def width=(value)
-    @width=value; @window.width=@window.width
+    super(value)
+    @window.width = @window.width
   end
 
   def x=(value)
-    @x=value; @window.width=@window.width
+    super(value)
+    @window.width = @window.width
   end
 
   def y=(value)
-    @y=value; @window.width=@window.width
+    super(value)
+    @window.width = @window.width
+  end
+
+  private
+
+  def needs_update?
+    return self.x != 0 || self.y != 0 || self.width != 0 || self.height != 0
   end
 end
-
 
 
 class Window

--- a/Data/Scripts/009_Objects and windows/003_Window.rb
+++ b/Data/Scripts/009_Objects and windows/003_Window.rb
@@ -5,7 +5,7 @@ class WindowCursorRect < Rect
   end
 
   def empty
-    return unless needs_update?
+    return unless needs_update?(0, 0, 0, 0)
 
     set(0, 0, 0, 0)
   end
@@ -15,7 +15,7 @@ class WindowCursorRect < Rect
   end
 
   def set(x, y, width, height)
-    return unless needs_update?
+    return unless needs_update?(x, y, width, height)
 
     super(x, y, width, height)
 
@@ -44,8 +44,8 @@ class WindowCursorRect < Rect
 
   private
 
-  def needs_update?
-    return self.x != 0 || self.y != 0 || self.width != 0 || self.height != 0
+  def needs_update?(x, y, width, height)
+    return self.x != x || self.y != y || self.width != width || self.height != height
   end
 end
 

--- a/Data/Scripts/009_Objects and windows/003_Window.rb
+++ b/Data/Scripts/009_Objects and windows/003_Window.rb
@@ -10,7 +10,7 @@ class WindowCursorRect < Rect
     set(0, 0, 0, 0)
   end
 
-  def isEmpty?
+  def empty?
     return self.x == 0 && self.y == 0 && self.width == 0 && self.height == 0
   end
 
@@ -305,7 +305,7 @@ class Window
         @cursoropacity+=8
         @cursorblink=0 if @cursoropacity>=255
       end
-      mustchange=true if !@cursor_rect.isEmpty?
+      mustchange=true if !@cursor_rect.empty?
     else
       mustchange=true if @cursoropacity!=128
       @cursoropacity=128

--- a/Data/Scripts/009_Objects and windows/004_SpriteWindow.rb
+++ b/Data/Scripts/009_Objects and windows/004_SpriteWindow.rb
@@ -1,63 +1,4 @@
 #===============================================================================
-#
-#===============================================================================
-class SpriteWindowCursorRect < Rect
-  def initialize(window)
-    @window=window
-    @x=0
-    @y=0
-    @width=0
-    @height=0
-  end
-
-  attr_reader :x,:y,:width,:height
-
-  def empty
-    needupdate=@x!=0 || @y!=0 || @width!=0 || @height!=0
-    if needupdate
-      @x=0
-      @y=0
-      @width=0
-      @height=0
-      @window.width=@window.width
-    end
-  end
-
-  def isEmpty?
-    return @x==0 && @y==0 && @width==0 && @height==0
-  end
-
-  def set(x,y,width,height)
-    needupdate=@x!=x || @y!=y || @width!=width || @height!=height
-    if needupdate
-      @x=x
-      @y=y
-      @width=width
-      @height=height
-      @window.width=@window.width
-    end
-  end
-
-  def height=(value)
-    @height=value; @window.width=@window.width
-  end
-
-  def width=(value)
-    @width=value; @window.width=@window.width
-  end
-
-  def x=(value)
-    @x=value; @window.width=@window.width
-  end
-
-  def y=(value)
-    @y=value; @window.width=@window.width
-  end
-end
-
-
-
-#===============================================================================
 # SpriteWindow is a class based on Window which emulates Window's functionality.
 # This class is necessary in order to change the viewport of windows (with
 # viewport=) and to make windows fade in and out (with tone=).
@@ -156,7 +97,7 @@ class SpriteWindow < Window
     @blend_type=0
     @contents_blend_type=0
     @contents_opacity=255
-    @cursor_rect=SpriteWindowCursorRect.new(self)
+    @cursor_rect=WindowCursorRect.new(self)
     @cursorblink=0
     @cursoropacity=255
     @pause=false


### PR DESCRIPTION
This PR removes `SpriteWindowCursorRect`, which was a duplicate of `WindowCursorRect`. `WindowCursorRect` has been reworked to use `super` and will no longer cause problems in newer Ruby versions.