### PR TITLE
Add Boolean module to TrueClass and FalseClass

### DIFF
--- a/Data/Scripts/001_Technical/002_Ruby Utilities.rb
+++ b/Data/Scripts/001_Technical/002_Ruby Utilities.rb
@@ -22,12 +22,20 @@ unless Comparable.method_defined? :clamp
 end
 
 #===============================================================================
-# class Boolean
+# module Boolean
 #===============================================================================
-class Boolean
+module Boolean
   def to_i
     return self ? 1 : 0
   end
+end
+
+class TrueClass
+  include Boolean
+end
+
+class FalseClass
+  include Boolean
 end
 
 #===============================================================================


### PR DESCRIPTION
The file `002_Ruby Utilities.rb` defines a `Boolean` class that is left unused. I propose turning it into a module and including it into `TrueClass` and `FalseClass`. This makes the `to_i` method available for both classes and allows us to use `validate` on boolean arguments like so:

```ruby
def foo(boolean_arg)
  validate boolean_arg => Boolean
  # ...
end
```

This is possible since we'll be able to do `obj.is_a?(Boolean)`.