### PR TITLE
Fix a crash in PokeBattle_Trainer.copy

### DIFF
--- a/Data/Scripts/014_Trainers/001b_Trainer_deprecated.rb
+++ b/Data/Scripts/014_Trainers/001b_Trainer_deprecated.rb
@@ -45,9 +45,8 @@ class PokeBattle_Trainer
   attr_reader :mysterygiftaccess, :mysterygift
 
   def self.copy(trainer)
-    ret = PlayerTrainer.new
-    ret.trainer_type          = trainer.trainertype
-    ret.name                  = trainer.name
+    validate trainer => self
+    ret = PlayerTrainer.new(trainer.name, trainer.trainertype)
     ret.id                    = trainer.id
     ret.character_ID          = trainer.metaID if trainer.metaID
     ret.outfit                = trainer.outfit if trainer.outfit


### PR DESCRIPTION
This PR fixes a crash in `PokeBattle_Trainer.copy`. It also validates the given trainer object.