### PR TITLE
Add support for timing using delta clocks

### DIFF
--- a/Data/Scripts/001_Technical/007_Errors.rb
+++ b/Data/Scripts/001_Technical/007_Errors.rb
@@ -50,14 +50,14 @@ def pbPrintException(e)
 
   print("#{message}\r\nThis exception was logged in #{errorlogline}.\r\nHold Ctrl after closing this message to copy it to the clipboard.")
   # Give a ~500ms coyote time to start holding Control
-  (Graphics.frame_rate / 2).ceil.times{
-    Graphics.update
+  t = System.delta
+  until (System.delta - t) >= 500000
     Input.update
     if Input.press?(Input::CTRL)
       Input.clipboard = message
       break
     end
-  }
+  end
 end
 
 def pbCriticalCode

--- a/Data/Scripts/020_System and utilities/005_PSystem_Utilities.rb
+++ b/Data/Scripts/020_System and utilities/005_PSystem_Utilities.rb
@@ -112,7 +112,7 @@ end
 def getConstantName(mod,value)
   mod = Object.const_get(mod) if mod.is_a?(Symbol)
   for c in mod.constants
-    return c if mod.const_get(c.to_sym).to_s==value
+    return c if mod.const_get(c.to_sym)==value
   end
   raise _INTL("Value {1} not defined by a constant in {2}",value,mod.name)
 end
@@ -120,7 +120,7 @@ end
 def getConstantNameOrValue(mod,value)
   mod = Object.const_get(mod) if mod.is_a?(Symbol)
   for c in mod.constants
-    return c if mod.const_get(c.to_sym).to_s==value
+    return c if mod.const_get(c.to_sym)==value
   end
   return value.inspect
 end

--- a/Data/Scripts/021_Debug/002_Animation editor/001_AnimEditor_SceneElements.rb
+++ b/Data/Scripts/021_Debug/002_Animation editor/001_AnimEditor_SceneElements.rb
@@ -263,6 +263,7 @@ class AnimationWindow < SpriteWrapper
     right.x+=self.x
     right.y+=self.y
     swatchrects=[]
+    repeattime = Input.time?(Input::MOUSELEFT) / 1000
     for i in 0...NUMFRAMES
       swatchrects.push(Rect.new(arrowwidth+i*96+self.x,self.y,96,96))
     end
@@ -276,7 +277,7 @@ class AnimationWindow < SpriteWrapper
     end
     # Left arrow
     if left.contains(mousepos[0],mousepos[1])
-      if Input.count(Input::MOUSELEFT)>30
+      if repeattime>750
         @start-=3
       else
         @start-=1
@@ -286,7 +287,7 @@ class AnimationWindow < SpriteWrapper
     end
     # Right arrow
     if right.contains(mousepos[0],mousepos[1])
-      if Input.count(Input::MOUSELEFT)>30
+      if repeattime>750
         @start+=3
       else
         @start+=1

--- a/Data/Scripts/021_Debug/002_Animation editor/002_AnimEditor_ControlsButtons.rb
+++ b/Data/Scripts/021_Debug/002_Animation editor/002_AnimEditor_ControlsButtons.rb
@@ -396,12 +396,13 @@ class Slider < UIControl
     left=toAbsoluteRect(@leftarrow)
     right=toAbsoluteRect(@rightarrow)
     oldvalue=self.curvalue
+    repeattime = Input.time?(Input::MOUSELEFT) / 1000
     # Left arrow
     if left.contains(mousepos[0],mousepos[1])
-      if Input.count(Input::MOUSELEFT)>100
+      if repeattime>2500
         self.curvalue-=10
         self.curvalue=self.curvalue.floor
-      elsif Input.count(Input::MOUSELEFT)>50
+      elsif repeattime>1250
         self.curvalue-=5
         self.curvalue=self.curvalue.floor
       else
@@ -413,10 +414,10 @@ class Slider < UIControl
     end
     #Right arrow
     if right.contains(mousepos[0],mousepos[1])
-      if Input.count(Input::MOUSELEFT)>100
+      if repeattime>2500
         self.curvalue+=10
         self.curvalue=self.curvalue.floor
-      elsif Input.count(Input::MOUSELEFT)>50
+      elsif repeattime>1250
         self.curvalue+=5
         self.curvalue=self.curvalue.floor
       else
@@ -644,11 +645,12 @@ class TextSlider < UIControl
     left=toAbsoluteRect(@leftarrow)
     right=toAbsoluteRect(@rightarrow)
     oldvalue=self.curvalue
+    repeattime = Input.time?(Input::MOUSELEFT) / 1000
     # Left arrow
     if left.contains(mousepos[0],mousepos[1])
-      if Input.count(Input::MOUSELEFT)>100
+      if repeattime>2500
         self.curvalue-=10
-      elsif Input.count(Input::MOUSELEFT)>50
+      elsif repeattime>1250
         self.curvalue-=5
       else
         self.curvalue-=1
@@ -658,9 +660,9 @@ class TextSlider < UIControl
     end
     # Right arrow
     if right.contains(mousepos[0],mousepos[1])
-      if Input.count(Input::MOUSELEFT)>100
+      if repeattime>2500
         self.curvalue+=10
-      elsif Input.count(Input::MOUSELEFT)>50
+      elsif repeattime>1250
         self.curvalue+=5
       else
         self.curvalue+=1

--- a/Data/Scripts/021_Debug/002_Animation editor/003_AnimEditor_Interpolation.rb
+++ b/Data/Scripts/021_Debug/002_Animation editor/003_AnimEditor_Interpolation.rb
@@ -20,7 +20,7 @@ class ControlPointSprite < SpriteWrapper
   end
 
   def mouseover
-    if Input.count(Input::MOUSELEFT)==0 || !@dragging
+    if Input.time?(Input::MOUSELEFT)==0 || !@dragging
       @dragging=false
       return
     end
@@ -389,7 +389,7 @@ def pbDefinePath(canvas)
         window.text = (mousepos) ? sprintf("(%d,%d)",mousepos[0],mousepos[1]) : "(??,??)"
         Graphics.update
         Input.update
-        if Input.triggerex?(:ESCAPE) || Input.count(Input::MOUSELEFT)==0
+        if Input.triggerex?(:ESCAPE) || Input.time?(Input::MOUSELEFT)==0
           break
         end
       end


### PR DESCRIPTION
A small update to mkxp-z that gives support for delta timing, as well as making `Input.repeat?` and `Input.repeatex?` timing FPS-independent. The latter works by adjusting the frame counts required for a button to count as repeating whenever the FPS is changed (It's still the exact same as before if the framerate is set to the default), so it might break things that depend on specific values in `Input.count` and `Input.repeatcount`.

Using the delta clocks is easy, and all values returned by these functions are in microseconds:

+ `System.delta` tracks the amount of time passed since MKXP's startup
+ `Graphics.delta` tracks the amount of time passed since the last time `Graphics.update` was called
+ `Input.delta` tracks the amount of time passed since the last time `Input.update` was called
+ `Input.time?` and `Input.timeex?` give the amount of time a repeating button has been held down.

They have countless uses, like being able to accurately figure out a player's playtime, coming up with RNG algorithms, benchmarking code, making animation or gameplay speed independent from the FPS, all kinds of stuff -- but I guess you know about that already.

Also, I made a correction to `getConstantName`, something I swear did not work when I was originally making things work with Ruby 3, but it broke again and changing it back let everything compile again, so whatever.