### PR TITLE
Remove all usage of missing doubleclick? method

### DIFF
--- a/Data/Scripts/021_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
+++ b/Data/Scripts/021_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
@@ -54,7 +54,7 @@ def pbImportAnim(animations,canvas,animwin)
     Graphics.update
     Input.update
     cmdwin.update
-    if (Input.trigger?(Input::C) || (cmdwin.doubleclick? rescue false)) && animfiles.length>0
+    if Input.trigger?(Input::C) && animfiles.length>0
       begin
         textdata=loadBase64Anim(IO.read(animfiles[cmdwin.index]))
         throw "Bad data" if !textdata.is_a?(PBAnimation)

--- a/Data/Scripts/021_Debug/002_Animation editor/005_AnimEditor_Functions.rb
+++ b/Data/Scripts/021_Debug/002_Animation editor/005_AnimEditor_Functions.rb
@@ -46,7 +46,7 @@ def pbSelectAnim(canvas,animwin)
     bmpwin.update
     ctlwin.update
     bmpwin.hue=ctlwin.value(0) if ctlwin.changed?(0)
-    if (Input.trigger?(Input::C) || (cmdwin.doubleclick? rescue false)) && animfiles.length>0
+    if Input.trigger?(Input::C) && animfiles.length>0
       bitmap=AnimatedBitmap.new("Graphics/Animations/"+cmdwin.commands[cmdwin.index],ctlwin.value(0)).deanimate
       canvas.animation.graphic=cmdwin.commands[cmdwin.index]
       canvas.animation.hue=ctlwin.value(0)
@@ -149,7 +149,7 @@ def pbAnimList(animations,canvas,animwin)
       cmdwin.index=animations.selected
       next
     end
-    if (Input.trigger?(Input::C) || (cmdwin.doubleclick? rescue false)) && animations.length>0
+    if Input.trigger?(Input::C) && animations.length>0
       cmd2=pbShowCommands(helpwindow,[
          _INTL("Load Animation"),
          _INTL("Rename"),
@@ -435,7 +435,7 @@ def pbTimingList(canvas)
         next
       end
     end
-    if (Input.trigger?(Input::C) || (cmdwin.doubleclick? rescue false))
+    if Input.trigger?(Input::C)
       redrawcmds=false
       if cmdwin.index==cmdNewSound # Add new sound
         newaudio=PBAnimTiming.new(0)
@@ -562,7 +562,7 @@ def pbSelectSE(canvas,audio)
     if maxsizewindow.changed?(6) # Cancel
       break
     end
-    if (Input.trigger?(Input::C) || (cmdwin.doubleclick? rescue false)) && animfiles.length>0
+    if Input.trigger?(Input::C) && animfiles.length>0
       filename=(cmdwin.index==0) ? "" : cmdwin.commands[cmdwin.index]
       displayname=(filename!="") ? filename : _INTL("<user's cry>")
       maxsizewindow.controls[0].text=_INTL("File: \"{1}\"",displayname)
@@ -625,7 +625,7 @@ def pbSelectBG(canvas,timing)
     if maxsizewindow.changed?(9) # Cancel
       break
     end
-    if (Input.trigger?(Input::C) || (cmdwin.doubleclick? rescue false)) && animfiles.length>0
+    if Input.trigger?(Input::C) && animfiles.length>0
       filename=(cmdwin.index==cmdErase) ? "" : cmdwin.commands[cmdwin.index]
       maxsizewindow.controls[0].text=_INTL("File: \"{1}\"",filename)
     elsif Input.trigger?(Input::B)

--- a/Data/Scripts/021_Debug/007_Editor_DataTypes.rb
+++ b/Data/Scripts/021_Debug/007_Editor_DataTypes.rb
@@ -1504,7 +1504,7 @@ def pbPropertyList(title,data,properties,saveprompt=false)
       elsif Input.trigger?(Input::B)
         selectedmap = -1
         break
-      elsif Input.trigger?(Input::C) || (list.doubleclick? rescue false)
+      elsif Input.trigger?(Input::C)
         propobj = properties[selectedmap][1]
         oldsetting = data[selectedmap]
         newsetting = propobj.set(properties[selectedmap][0],oldsetting)

--- a/Data/Scripts/021_Debug/008_Editor_Listers.rb
+++ b/Data/Scripts/021_Debug/008_Editor_Listers.rb
@@ -44,7 +44,7 @@ def pbListScreen(title,lister)
     if Input.trigger?(Input::B)
       selectedmap = -1
       break
-    elsif Input.trigger?(Input::C) || (list.doubleclick? rescue false)
+    elsif Input.trigger?(Input::C)
       break
     end
   end
@@ -97,7 +97,7 @@ def pbListScreenBlock(title,lister)
       lister.refresh(list.index)
     elsif Input.trigger?(Input::B)
       break
-    elsif Input.trigger?(Input::C) || (list.doubleclick? rescue false)
+    elsif Input.trigger?(Input::C)
       yield(Input::C, lister.value(selectedmap))
       list.commands = lister.commands
       if list.index==list.commands.length

--- a/Data/Scripts/021_Debug/009_Editor_Utilities.rb
+++ b/Data/Scripts/021_Debug/009_Editor_Utilities.rb
@@ -261,7 +261,7 @@ def pbCommands2(cmdwindow,commands,cmdIfCancel,defaultindex=-1,noresize=false)
         command = cmdIfCancel
         break
       end
-    elsif Input.trigger?(Input::C) || (cmdwindow.doubleclick? rescue false)
+    elsif Input.trigger?(Input::C)
       command = cmdwindow.index
       break
     end
@@ -315,7 +315,7 @@ def pbCommands3(cmdwindow,commands,cmdIfCancel,defaultindex=-1,noresize=false)
         command = [0,cmdIfCancel]
         break
       end
-    elsif Input.trigger?(Input::C) || (cmdwindow.doubleclick? rescue false)
+    elsif Input.trigger?(Input::C)
       command = [0,cmdwindow.index]
       break
     end
@@ -387,7 +387,7 @@ def pbCommandsSortable(cmdwindow,commands,cmdIfCancel,defaultindex=-1,sortable=f
     elsif Input.trigger?(Input::B)
       command = [0,(cmdIfCancel>0) ? cmdIfCancel-1 : cmdIfCancel]
       break
-    elsif Input.trigger?(Input::C) || (cmdwindow.doubleclick? rescue false)
+    elsif Input.trigger?(Input::C)
       command = [0,cmdwindow.index]
       break
     end


### PR DESCRIPTION
There is code in Essentials that calls a missing `doubleclick?` method. The statements are rescued, but raising and rescuing exceptions every frame isn't ideal. Also, since running the game with the debug console prints out an alert for every exception, including rescued ones, this happens:

![hTYPxZj0Ll](https://user-images.githubusercontent.com/12786937/109273643-224f3b00-781b-11eb-87d2-a245df5a1d12.gif)

This PR removes the code in question.