### PR TITLE
Remove unnecessary utilities

### DIFF
--- a/Data/Scripts/001_Technical/002_Ruby Utilities.rb
+++ b/Data/Scripts/001_Technical/002_Ruby Utilities.rb
@@ -8,43 +8,9 @@ class Class
 end
 
 #===============================================================================
-# module Comparable
-#===============================================================================
-unless Comparable.method_defined? :clamp
-  module Comparable
-    def clamp(min, max)
-      if max - min < 0
-        raise ArgumentError("min argument must be smaller than max argument")
-      end
-      return (self > max) ? max : (self < min) ? min : self
-    end
-  end
-end
-
-#===============================================================================
-# class Boolean
-#===============================================================================
-class Boolean
-  def to_i
-    return self ? 1 : 0
-  end
-end
-
-#===============================================================================
 # class String
 #===============================================================================
 class String
-  def starts_with?(str)
-    proc = (self[0...str.length] == str) if self.length >= str.length
-    return proc || false
-  end
-
-  def ends_with?(str)
-    e = self.length - 1
-    proc = (self[(e-str.length)...e] == str) if self.length >= str.length
-    return proc || false
-  end
-
   def starts_with_vowel?
     return ['a', 'e', 'i', 'o', 'u'].include?(self[0, 1].downcase)
   end
@@ -55,24 +21,6 @@ class String
 
   def last(n = 1)
     return self[-n..-1] || self
-  end
-
-  def bytesize
-    return self.size
-  end
-
-  def capitalize
-    proc = self.scan(/./)
-    proc[0] = proc[0].upcase
-    string = ""
-    for letter in proc
-      string += letter
-    end
-    return string
-  end
-
-  def capitalize!
-    self.replace(self.capitalize)
   end
 
   def blank?
@@ -115,43 +63,12 @@ class Numeric
 end
 
 #===============================================================================
-# class Integer
-#===============================================================================
-class Integer
-  # Returns an array containing each digit of the number in turn.
-  def digits(base = 10)
-    quotient, remainder = divmod(base)
-    return (quotient == 0) ? [remainder] : quotient.digits(base).push(remainder)
-  end
-end
-
-#===============================================================================
 # class Array
 #===============================================================================
 class Array
-  def first
-    return self[0]
-  end
-
-  def last
-    return self[self.length-1]
-  end
-
   def ^(other)   # xor of two arrays
     return (self|other) - (self&other)
   end
-
-  def shuffle
-    dup.shuffle!
-  end unless method_defined? :shuffle
-
-  def shuffle!
-    (size - 1).times do |i|
-      r = i + rand(size - i)
-      self[i], self[r] = self[r], self[i]
-    end
-    self
-  end unless method_defined? :shuffle!
 end
 
 #===============================================================================

--- a/Data/Scripts/012_Battle/005_Battle scene/004_PokeBattle_SceneElements.rb
+++ b/Data/Scripts/012_Battle/005_Battle scene/004_PokeBattle_SceneElements.rb
@@ -191,7 +191,8 @@ class PokemonDataBox < SpriteWrapper
   end
 
   def pbDrawNumber(number,btmp,startX,startY,align=0)
-    n = (number==-1) ? [10] : number.to_i.digits   # -1 means draw the / character
+    # -1 means draw the / character
+    n = (number == -1) ? [10] : number.to_i.digits.reverse
     charWidth  = @numbersBitmap.width/11
     charHeight = @numbersBitmap.height
     startX -= charWidth*n.length if align==1


### PR DESCRIPTION
This PR removes the following methods from `Ruby_Utilities.rb`:

- `Comparable#clamp` (already exists)
- `Boolean#to_i` (removed the Boolean class as it is unused)
- `String#starts_with?` (already exists as `String#start_with?`)
- `String#ends_with?` (already exists as `String#end_with?`)
- `String#bytesize` (already exists)
- `String#capitalize(!)` (already exists)
- `Integer#digits` (already exists)
- `Array#first` and `Array#last` (already exist)
- `Array#shuffle(!)` (already exists)

Ruby's own `Integer#digits` returns an array with the least significant digit as the first array element. That means that the method's only usage has to be appended with a call to `Array#reverse`, which I've done in this PR.