### PR TITLE
Module#deprecated_method_alias

### DIFF
--- a/Data/Scripts/001_Technical/009_Deprecation.rb
+++ b/Data/Scripts/001_Technical/009_Deprecation.rb
@@ -5,8 +5,8 @@ module Deprecation
 
   # Sends a warning of a deprecated method into the debug console.
   # @param method_name [String] name of the deprecated method
-  # @param removal_version [String] name of the version the method is removed in (optional)
-  # @param alternative [String] preferred alternative method (optional)
+  # @param removal_version [String] version the method is removed in
+  # @param alternative [String] preferred alternative method
   def warn_method(method_name, removal_version = nil, alternative = nil)
     text = _INTL('WARN: usage of deprecated method "{1}" or its alias.', method_name)
     unless removal_version.nil?
@@ -24,29 +24,25 @@ end
 class Module
   private
 
-  # Creates a deprecated alias for an instance method.
+  # Creates a deprecated alias for a method.
   # Using it sends a warning to the debug console.
-  # @param alias_name [Symbol] the name of the new alias
-  # @param aliased_method_name [Symbol] the name of the aliased method
-  # @param removal_version [String] name of the version the alias is removed in (optional)
-  def deprecated_instance_method_alias(alias_name, aliased_method_name, removal_version = nil)
-    define_method(alias_name) do |*args|
-      alias_full_name = format('%s#%s', self.class.name, alias_name.to_s)
-      aliased_method_full_name = format('%s#%s', self.class.name, aliased_method_name.to_s)
-      Deprecation.warn_method(alias_full_name, removal_version, aliased_method_full_name)
-      method(aliased_method_name).call(*args)
-    end
-  end
+  # @param name [Symbol] name of the new alias
+  # @param aliased_method [Symbol] name of the aliased method
+  # @param removal_in [String] version the alias is removed in
+  # @param class_method [Boolean] whether the method is a class method
+  def deprecated_method_alias(name, aliased_method, removal_in: nil, class_method: false)
+    validate name => Symbol, aliased_method => Symbol, removal_in => [NilClass, String],
+             class_method => [TrueClass, FalseClass]
 
-  # Creates a deprecated alias for a class method.
-  # Using it sends a warning to the debug console.
-  # @param (see #deprecated_instance_method_alias)
-  def deprecated_class_method_alias(alias_name, aliased_method_name, removal_version = nil)
-    self.class.send(:define_method, alias_name) do |*args|
-      alias_full_name = format('%s::%s', self.name, alias_name.to_s)
-      aliased_method_full_name = format('%s::%s', self.name, aliased_method_name.to_s)
-      Deprecation.warn_method(alias_full_name, removal_version, aliased_method_full_name)
-      method(aliased_method_name).call(*args)
+    target = class_method ? self.class : self
+    class_name = self.name
+    delimiter = class_method ? '.' : '#'
+
+    target.define_method(name) do |*args, **kvargs|
+      alias_name = format('%s%s%s', class_name, delimiter, name)
+      aliased_method_name = format('%s%s%s', class_name, delimiter, aliased_method)
+      Deprecation.warn_method(alias_name, removal_in, aliased_method_name)
+      method(aliased_method).call(*args, **kvargs)
     end
   end
 end

--- a/Data/Scripts/001_Technical/009_Deprecation.rb
+++ b/Data/Scripts/001_Technical/009_Deprecation.rb
@@ -36,6 +36,11 @@ class Module
 
     target = class_method ? self.class : self
     class_name = self.name
+
+    unless target.method_defined?(aliased_method)
+      raise ArgumentError, "#{class_name} does not have method #{aliased_method} defined"
+    end
+
     delimiter = class_method ? '.' : '#'
 
     target.define_method(name) do |*args, **kvargs|

--- a/Data/Scripts/014_Trainers/001b_Trainer_deprecated.rb
+++ b/Data/Scripts/014_Trainers/001b_Trainer_deprecated.rb
@@ -2,39 +2,39 @@
 # Deprecated
 #===============================================================================
 class PlayerTrainer
-  alias fullname full_name
-  alias publicID public_ID
-  alias secretID secret_ID
-  alias getForeignID make_foreign_ID
-  alias trainerTypeName trainer_type_name
-  alias moneyEarned base_money
-  alias skill skill_level
-  alias skillCode skill_code
-  alias hasSkillCode has_skill_code?
-  alias pokemonParty pokemon_party
-  alias ablePokemonParty able_party
-  alias partyCount party_count
-  alias pokemonCount pokemon_count
-  alias ablePokemonCount able_pokemon_count
-  alias firstParty first_party
-  alias firstPokemon first_pokemon
-  alias firstAblePokemon first_able_pokemon
-  alias lastParty last_party
-  alias lastPokemon last_pokemon
-  alias lastAblePokemon last_able_pokemon
-  alias formseen seen_forms
-  alias formlastseen last_seen_forms
-  alias shadowcaught owned_shadow
-  alias numbadges badge_count
-  alias pokedexSeen seen_count
-  alias pokedexOwned owned_count
-  alias numFormsSeen seen_forms_count
-  alias clearPokedex clear_pokedex
-  alias metaID character_ID
-  alias mysterygiftaccess mystery_gift_unlocked
-  alias mysterygift mystery_gifts
-  alias setSeen set_seen
-  alias setOwned set_owned
+  deprecated_method_alias :fullname, :full_name, removal_in: 'v20'
+  deprecated_method_alias :publicID, :public_ID, removal_in: 'v20'
+  deprecated_method_alias :secretID, :secret_ID, removal_in: 'v20'
+  deprecated_method_alias :getForeignID, :make_foreign_ID, removal_in: 'v20'
+  deprecated_method_alias :trainerTypeName, :trainer_type_name, removal_in: 'v20'
+  deprecated_method_alias :moneyEarned, :base_money, removal_in: 'v20'
+  deprecated_method_alias :skill, :skill_level, removal_in: 'v20'
+  deprecated_method_alias :skillCode, :skill_code, removal_in: 'v20'
+  deprecated_method_alias :hasSkillCode, :has_skill_code?, removal_in: 'v20'
+  deprecated_method_alias :pokemonParty, :pokemon_party, removal_in: 'v20'
+  deprecated_method_alias :ablePokemonParty, :able_party, removal_in: 'v20'
+  deprecated_method_alias :partyCount, :party_count, removal_in: 'v20'
+  deprecated_method_alias :pokemonCount, :pokemon_count, removal_in: 'v20'
+  deprecated_method_alias :ablePokemonCount, :able_pokemon_count, removal_in: 'v20'
+  deprecated_method_alias :firstParty, :first_party, removal_in: 'v20'
+  deprecated_method_alias :firstPokemon, :first_pokemon, removal_in: 'v20'
+  deprecated_method_alias :firstAblePokemon, :first_able_pokemon, removal_in: 'v20'
+  deprecated_method_alias :lastParty, :last_party, removal_in: 'v20'
+  deprecated_method_alias :lastPokemon, :last_pokemon, removal_in: 'v20'
+  deprecated_method_alias :lastAblePokemon, :last_able_pokemon, removal_in: 'v20'
+  deprecated_method_alias :formseen, :seen_forms, removal_in: 'v20'
+  deprecated_method_alias :formlastseen, :last_seen_forms, removal_in: 'v20'
+  deprecated_method_alias :shadowcaught, :owned_shadow, removal_in: 'v20'
+  deprecated_method_alias :numbadges, :badge_count, removal_in: 'v20'
+  deprecated_method_alias :pokedexSeen, :seen_count, removal_in: 'v20'
+  deprecated_method_alias :pokedexOwned, :owned_count, removal_in: 'v20'
+  deprecated_method_alias :numFormsSeen, :seen_forms_count, removal_in: 'v20'
+  deprecated_method_alias :clearPokedex, :clear_pokedex, removal_in: 'v20'
+  deprecated_method_alias :metaID, :character_ID, removal_in: 'v20'
+  deprecated_method_alias :mysterygiftaccess, :mystery_gift_unlocked, removal_in: 'v20'
+  deprecated_method_alias :mysterygift, :mystery_gifts, removal_in: 'v20'
+  deprecated_method_alias :setSeen, :set_seen, removal_in: 'v20'
+  deprecated_method_alias :setOwned, :set_owned, removal_in: 'v20'
 end
 
 class PokeBattle_Trainer

--- a/Data/Scripts/016_Pokemon/010_Pokemon_Deprecated.rb
+++ b/Data/Scripts/016_Pokemon/010_Pokemon_Deprecated.rb
@@ -187,15 +187,15 @@ class Pokemon
     self.item = value
   end
 
-  alias healStatus heal_status
-  alias pbLearnMove learn_move
-  alias pbDeleteMove forget_move
-  alias pbDeleteMoveAtIndex forget_move_at_index
-  alias pbRecordFirstMoves record_first_moves
-  alias pbAddFirstMove add_first_move
-  alias pbRemoveFirstMove remove_first_move
-  alias pbClearFirstMoves clear_first_moves
-  alias pbUpdateShadowMoves update_shadow_moves
+  deprecated_method_alias :healStatus, :heal_status, removal_in: 'v20'
+  deprecated_method_alias :pbLearnMove, :learn_move, removal_in: 'v20'
+  deprecated_method_alias :pbDeleteMove, :forget_move, removal_in: 'v20'
+  deprecated_method_alias :pbDeleteMoveAtIndex, :forget_move_at_index, removal_in: 'v20'
+  deprecated_method_alias :pbRecordFirstMoves, :record_first_moves, removal_in: 'v20'
+  deprecated_method_alias :pbAddFirstMove, :add_first_move, removal_in: 'v20'
+  deprecated_method_alias :pbRemoveFirstMove, :remove_first_move, removal_in: 'v20'
+  deprecated_method_alias :pbClearFirstMoves, :clear_first_moves, removal_in: 'v20'
+  deprecated_method_alias :pbUpdateShadowMoves, :update_shadow_moves, removal_in: 'v20'
 end
 
 # (see Pokemon#initialize)

--- a/Data/Scripts/016_Pokemon/010_Pokemon_Deprecated.rb
+++ b/Data/Scripts/016_Pokemon/010_Pokemon_Deprecated.rb
@@ -96,6 +96,7 @@ end
 class Pokemon
   # @deprecated Use {MAX_NAME_SIZE} instead. This alias is slated to be removed in v20.
   MAX_POKEMON_NAME_SIZE = MAX_NAME_SIZE
+  deprecate_constant :MAX_POKEMON_NAME_SIZE
 
   # @deprecated Use {Owner#public_id} instead. This alias is slated to be removed in v20.
   def publicID
@@ -151,12 +152,6 @@ class Pokemon
     @owner.language = value
   end
 
-  # @deprecated Use {Pokemon#gender=} instead. This alias is slated to be removed in v20.
-  def setGender(value)
-    Deprecation.warn_method('Pokemon#setGender', 'v20', 'Pokemon#gender=')
-    self.gender = value
-  end
-
   # @deprecated Use {Pokemon#shiny=} instead. This alias is slated to be removed in v20.
   def makeShiny
     Deprecation.warn_method('Pokemon#makeShiny', 'v20', 'Pokemon#shiny=true')
@@ -169,23 +164,10 @@ class Pokemon
     self.shiny = false
   end
 
-  # @deprecated Use {Pokemon#ability_index=} instead. This alias is slated to be removed in v20.
-  def setAbility(value)
-    Deprecation.warn_method('Pokemon#setAbility', 'v20', 'Pokemon#ability_index=')
-    self.ability_index = value
-  end
-
-  # @deprecated Use {Pokemon#nature=} instead. This alias is slated to be removed in v20.
-  def setNature(value)
-    Deprecation.warn_method('Pokemon#setNature', 'v20', 'Pokemon#nature=')
-    self.nature = value
-  end
-
-  # @deprecated Use {Pokemon#item=} instead. This alias is slated to be removed in v20.
-  def setItem(value)
-    Deprecation.warn_method('Pokemon#setItem', 'v20', 'Pokemon#item=')
-    self.item = value
-  end
+  deprecated_method_alias :setGender, :gender=, removal_in: 'v20'
+  deprecated_method_alias :setAbility, :ability_index=, removal_in: 'v20'
+  deprecated_method_alias :setNature, :nature=, removal_in: 'v20'
+  deprecated_method_alias :setItem, :item=, removal_in: 'v20'
 
   deprecated_method_alias :healStatus, :heal_status, removal_in: 'v20'
   deprecated_method_alias :pbLearnMove, :learn_move, removal_in: 'v20'


### PR DESCRIPTION
This PR takes the unused `Module#deprecated_instance_method_alias` and `Module#deprecated_class_method_alias` and combines them into a single `Module#deprecated_method_alias` method. Its usage is as follows:

```ruby
class Foo
  # the removal_in keyword argument is optional
  deprecated_method_alias :oldMethod, :new_method, removal_in: 'vXX'
  # for class methods
  deprecated_method_alias :oldMethod, :new_method, removal_in: 'vXX', class_method: true
end
```

Deprecated aliases call `Deprecation.warn_method` automatically.

This PR takes the existing deprecated aliases and replaces them with calls to `deprecated_method_alias`.