### PR TITLE
messages.dat not loading properly after Compile

### DIFF
--- a/Data/Scripts/001_Technical/001_MKXP_Compatibility.rb
+++ b/Data/Scripts/001_Technical/001_MKXP_Compatibility.rb
@@ -12,6 +12,7 @@ class Bitmap
 
   def draw_text(x, y, width, height, text, align = 0)
     height = text_size(text).height
+    text.force_encoding(Encoding::UTF_8)
     mkxp_draw_text(x, y, width, height, text, align)
   end
 end

--- a/Data/Scripts/001_Technical/001_MKXP_Compatibility.rb
+++ b/Data/Scripts/001_Technical/001_MKXP_Compatibility.rb
@@ -12,7 +12,6 @@ class Bitmap
 
   def draw_text(x, y, width, height, text, align = 0)
     height = text_size(text).height
-    text.force_encoding(Encoding::UTF_8)
     mkxp_draw_text(x, y, width, height, text, align)
   end
 end

--- a/Data/Scripts/021_Compiler/001_Compiler.rb
+++ b/Data/Scripts/021_Compiler/001_Compiler.rb
@@ -677,9 +677,6 @@ module Compiler
   #=============================================================================
   def compile_all(mustCompile)
     FileLineData.clear
-    if (!$INEDITOR || Settings::LANGUAGES.length < 2) && safeExists?("Data/messages.dat")
-      MessageTypes.loadMessageFile("Data/messages.dat")
-    end
     if mustCompile
       echoln _INTL("*** Starting full compile ***")
       echoln ""
@@ -732,8 +729,11 @@ module Compiler
       echoln _INTL("*** Finished full compile ***")
       echoln ""
       System.reload_cache
-      MessageTypes.loadMessageFile("Data/messages.dat")
+      if (!$INEDITOR || Settings::LANGUAGES.length < 2) && safeExists?("Data/messages.dat")
+        MessageTypes.loadMessageFile("Data/messages.dat")
+      end
     end
+
     pbSetWindowText(nil)
   end
 

--- a/Data/Scripts/021_Compiler/001_Compiler.rb
+++ b/Data/Scripts/021_Compiler/001_Compiler.rb
@@ -732,6 +732,7 @@ module Compiler
       echoln _INTL("*** Finished full compile ***")
       echoln ""
       System.reload_cache
+      MessageTypes.loadMessageFile("Data/messages.dat")
     end
     pbSetWindowText(nil)
   end

--- a/Data/Scripts/021_Compiler/001_Compiler.rb
+++ b/Data/Scripts/021_Compiler/001_Compiler.rb
@@ -733,7 +733,6 @@ module Compiler
         MessageTypes.loadMessageFile("Data/messages.dat")
       end
     end
-
     pbSetWindowText(nil)
   end
 


### PR DESCRIPTION
I just added `text.force_encoding(Encoding::UTF_8)` to the def draw_text

might be a temporary solution until we figure out the compiler bug
(ignore my first closed PR)