### PR TITLE
Fix Crash on attempting to get Favored Types

### DIFF
--- a/Data/Scripts/012_Overworld/002_Battle triggering/003_Overworld_WildEncounters.rb
+++ b/Data/Scripts/012_Overworld/002_Battle triggering/003_Overworld_WildEncounters.rb
@@ -279,7 +279,7 @@ class PokemonEncounters
       if favored_type
         new_enc_list = []
         enc_list.each do |enc|
-          species_data = GameData::Species.get(enc[0])
+          species_data = GameData::Species.get(enc[1])
           t1 = species_data.type1
           t2 = species_data.type2
           new_enc_list.push(enc) if t1 == favored_type || t2 == favored_type


### PR DESCRIPTION
Discovered favored types were still set to pull the value which is now relative probability rather than species type, fixed this error