### PR TITLE
Protect Kyurem from knowing duplicate moves

### DIFF
--- a/Data/Scripts/014_Pokemon/001_Pokemon-related/001_FormHandlers.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon-related/001_FormHandlers.rb
@@ -341,7 +341,7 @@ MultipleForms.register(:KYUREM,{
   "onSetForm" => proc { |pkmn, form, oldForm|
     case form
     when 0   # Normal
-	    pkmn.moves.each_with_index do |move,i|
+      pkmn.moves.each_with_index do |move,i|
         if [:SCARYFACE].include?(move.id)
           pkmn.pbDeleteMoveAtIndex(i)
         end

--- a/Data/Scripts/014_Pokemon/001_Pokemon-related/001_FormHandlers.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon-related/001_FormHandlers.rb
@@ -341,6 +341,11 @@ MultipleForms.register(:KYUREM,{
   "onSetForm" => proc { |pkmn, form, oldForm|
     case form
     when 0   # Normal
+	    pkmn.moves.each_with_index do |move,i|
+        if [:SCARYFACE].include?(move.id)
+          pkmn.pbDeleteMoveAtIndex(i)
+        end
+      end
       pkmn.moves.each do |move|
         if [:ICEBURN, :FREEZESHOCK].include?(move.id)
           move.id = :GLACIATE if GameData::Move.exists?(:GLACIATE)


### PR DESCRIPTION
Applying the fix provided in https://youtu.be/xHA0VomyVnM to protect Kyurem from knowing two (or possibly more) Scary Faces after separation. This is to mimic the measure used in the official games, where Scary Face became a TM move.