### PR TITLE
Option Send to Boxes

### DIFF
--- a/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
@@ -11,6 +11,37 @@ module Battle::CatchAndStoreMixin
         pkmn.name = nickname
       end
     end
+    # Choose what will happen to the Pokémon
+    if pbPlayer.party_full? && $PokemonSystem.sendtoboxes == 0
+      loop do
+        commands = [_INTL("Add to your party"),
+                    _INTL("Send to a Box"),
+                    _INTL("See {1}'s summary", pkmn.name)]
+        command = pbMessage(_INTL("Where do you want to send {1} to?", pkmn.name), commands, -1)
+        if command == 0
+          pbDisplayPaused(_INTL("Please select a Pokémon to swap from your party."))
+          @scene.pbChoosePokemon(1, 3)
+          chosen = pbGet(1)
+          next unless chosen.positive?
+          pkmn_added             = pkmn
+          pkmn                   = pbPlayer.party[chosen].clone
+          pbPlayer.party[chosen] = pkmn_added
+          stored_box = @peer.pbStorePokemon(pbPlayer, pkmn)
+          box_name   = @peer.pbBoxName(stored_box)
+          pbDisplayPaused(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{2}\"!",
+                                pkmn_added.name, pkmn.name, box_name))
+          @initialItems[0][chosen] = pkmn_added.item_id if @initialItems
+          return
+        elsif command == 2
+          pbFadeOutIn {
+            scene  = PokemonSummary_Scene.new
+            screen = PokemonSummaryScreen.new(scene, false)
+            screen.pbStartScreen([pkmn], 0)
+          }
+        end
+        break unless command > 1
+      end
+    end
     # Store the Pokémon
     stored_box = @peer.pbStorePokemon(pbPlayer, pkmn)
     if stored_box < 0

--- a/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
@@ -26,9 +26,9 @@ module Battle::CatchAndStoreMixin
           pkmn_added             = pkmn
           pkmn                   = pbPlayer.party[chosen].clone
           pbPlayer.party[chosen] = pkmn_added
-          stored_box = @peer.pbStorePokemon(pbPlayer, pkmn)
-          box_name   = @peer.pbBoxName(stored_box)
-          pbDisplayPaused(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{2}\"!",
+          stored_box             = @peer.pbStorePokemon(pbPlayer, pkmn)
+          box_name               = @peer.pbBoxName(stored_box)
+          pbDisplayPaused(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{3}\"!",
                                 pkmn_added.name, pkmn.name, box_name))
           @initialItems[0][chosen] = pkmn_added.item_id if @initialItems
           return

--- a/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
@@ -24,7 +24,7 @@ module Battle::CatchAndStoreMixin
           chosen = pbGet(1)
           next unless chosen.positive?
           pkmn_added             = pkmn
-          pkmn                   = pbPlayer.party[chosen].clone
+          pkmn                   = pbPlayer.party[chosen]
           pbPlayer.party[chosen] = pkmn_added
           stored_box             = @peer.pbStorePokemon(pbPlayer, pkmn)
           box_name               = @peer.pbBoxName(stored_box)

--- a/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
@@ -17,8 +17,8 @@ module Battle::CatchAndStoreMixin
         commands = [_INTL("Add to your party"),
                     _INTL("Send to a Box"),
                     _INTL("See {1}'s summary", pkmn.name)]
-        command = pbMessage(_INTL("Where do you want to send {1} to?", pkmn.name), commands, -1)
-        if command == 0
+        case command = pbMessage(_INTL("Where do you want to send {1} to?", pkmn.name), commands, -1)
+        when 0
           pbDisplayPaused(_INTL("Please select a Pokémon to swap from your party."))
           @scene.pbChoosePokemon(1, 3)
           chosen = pbGet(1)
@@ -32,7 +32,7 @@ module Battle::CatchAndStoreMixin
                                 pkmn_added.name, pkmn.name, box_name))
           @initialItems[0][chosen] = pkmn_added.item_id if @initialItems
           return
-        elsif command == 2
+        when 2
           pbFadeOutIn {
             scene  = PokemonSummary_Scene.new
             screen = PokemonSummaryScreen.new(scene, false)

--- a/Data/Scripts/016_UI/015_UI_Options.rb
+++ b/Data/Scripts/016_UI/015_UI_Options.rb
@@ -5,6 +5,7 @@ class PokemonSystem
   attr_accessor :textspeed
   attr_accessor :battlescene
   attr_accessor :battlestyle
+  attr_accessor :sendtoboxes
   attr_accessor :givenicknames
   attr_accessor :frame
   attr_accessor :textskin
@@ -19,6 +20,7 @@ class PokemonSystem
     @textspeed     = 1     # Text speed (0=slow, 1=normal, 2=fast)
     @battlescene   = 0     # Battle effects (animations) (0=on, 1=off)
     @battlestyle   = 0     # Battle style (0=switch, 1=set)
+    @sendtoboxes   = 0     # Send to boxes (0=manual, 1=automatic)
     @givenicknames = 0     # Give nicknames (0=give, 1=don't give)
     @frame         = 0     # Default window frame (see also Settings::MENU_WINDOWSKINS)
     @textskin      = 0     # Speech frame
@@ -466,9 +468,19 @@ MenuHandlers.add(:options_menu, :movement_style, {
   "set_proc"    => proc { |value, _sceme| $PokemonSystem.runstyle = value }
 })
 
+MenuHandlers.add(:options_menu, :send_to_boxes, {
+  "name"        => _INTL("Send to Boxes"),
+  "order"       => 70,
+  "type"        => EnumOption,
+  "parameters"  => [_INTL("Manual"), _INTL("Automatic")],
+  "description" => _INTL("You can choose to have Pokémon automatically sent to your Boxes or not when your party is full."),
+  "get_proc"    => proc { next $PokemonSystem.sendtoboxes },
+  "set_proc"    => proc { |value, _scene| $PokemonSystem.sendtoboxes = value }
+})
+
 MenuHandlers.add(:options_menu, :give_nicknames, {
   "name"        => _INTL("Give Nicknames"),
-  "order"       => 70,
+  "order"       => 80,
   "type"        => EnumOption,
   "parameters"  => [_INTL("Give"), _INTL("Don't give")],
   "description" => _INTL("Choose whether you can give a nickname to a Pokémon when you obtain it."),
@@ -478,7 +490,7 @@ MenuHandlers.add(:options_menu, :give_nicknames, {
 
 MenuHandlers.add(:options_menu, :speech_frame, {
   "name"        => _INTL("Speech Frame"),
-  "order"       => 80,
+  "order"       => 90,
   "type"        => NumberOption,
   "parameters"  => 1..Settings::SPEECH_WINDOWSKINS.length,
   "description" => _INTL("Choose the appearance of dialogue boxes."),
@@ -493,7 +505,7 @@ MenuHandlers.add(:options_menu, :speech_frame, {
 
 MenuHandlers.add(:options_menu, :menu_frame, {
   "name"        => _INTL("Menu Frame"),
-  "order"       => 90,
+  "order"       => 100,
   "type"        => NumberOption,
   "parameters"  => 1..Settings::MENU_WINDOWSKINS.length,
   "description" => _INTL("Choose the appearance of menu boxes."),
@@ -508,7 +520,7 @@ MenuHandlers.add(:options_menu, :menu_frame, {
 
 MenuHandlers.add(:options_menu, :text_input_style, {
   "name"        => _INTL("Text Entry"),
-  "order"       => 100,
+  "order"       => 110,
   "type"        => EnumOption,
   "parameters"  => [_INTL("Cursor"), _INTL("Keyboard")],
   "description" => _INTL("Choose how you want to enter text."),
@@ -518,7 +530,7 @@ MenuHandlers.add(:options_menu, :text_input_style, {
 
 MenuHandlers.add(:options_menu, :screen_size, {
   "name"        => _INTL("Screen Size"),
-  "order"       => 110,
+  "order"       => 120,
   "type"        => EnumOption,
   "parameters"  => [_INTL("S"), _INTL("M"), _INTL("L"), _INTL("XL"), _INTL("Full")],
   "description" => _INTL("Choose the size of the game window."),

--- a/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
+++ b/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
@@ -34,7 +34,7 @@ def pbStorePokemon(pkmn)
         chosen = pbGet(1)
         next unless chosen.positive?
         pkmn_added             = pkmn
-        pkmn                   = $player.party[chosen].clone
+        pkmn                   = $player.party[chosen]
         $player.party[chosen]  = pkmn_added
         stored_box             = $PokemonStorage.pbStoreCaught(pkmn)
         box_name               = $PokemonStorage[stored_box].name

--- a/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
+++ b/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
@@ -36,11 +36,10 @@ def pbStorePokemon(pkmn)
         pkmn_added             = pkmn
         pkmn                   = $player.party[chosen].clone
         $player.party[chosen]  = pkmn_added
-        stored_box = $PokemonStorage.pbStoreCaught(pkmn)
-        box_name   = $PokemonStorage[stored_box].name
-        pbMessage(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{2}\"!",
+        stored_box             = $PokemonStorage.pbStoreCaught(pkmn)
+        box_name               = $PokemonStorage[stored_box].name
+        pbMessage(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{3}\"!",
                         pkmn_added.name, pkmn.name, box_name))
-        @initialItems[0][chosen] = pkmn_added.item_id if @initialItems
         return
       elsif command == 2
         pbFadeOutIn {

--- a/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
+++ b/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
@@ -21,6 +21,37 @@ def pbStorePokemon(pkmn)
     return
   end
   pkmn.record_first_moves
+  # Choose what will happen to the Pokémon
+  if $player.party_full? && $PokemonSystem.sendtoboxes == 0
+    loop do
+      commands = [_INTL("Add to your party"),
+                  _INTL("Send to a Box"),
+                  _INTL("See {1}'s summary", pkmn.name)]
+      command = pbMessage(_INTL("Where do you want to send {1} to?", pkmn.name), commands, -1)
+      if command == 0
+        pbMessage(_INTL("Please select a Pokémon to swap from your party."))
+        @scene.pbChoosePokemon(1, 3)
+        chosen = pbGet(1)
+        next unless chosen.positive?
+        pkmn_added             = pkmn
+        pkmn                   = $player.party[chosen].clone
+        $player.party[chosen]  = pkmn_added
+        stored_box = $PokemonStorage.pbStoreCaught(pkmn)
+        box_name   = $PokemonStorage[stored_box].name
+        pbMessage(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{2}\"!",
+                        pkmn_added.name, pkmn.name, box_name))
+        @initialItems[0][chosen] = pkmn_added.item_id if @initialItems
+        return
+      elsif command == 2
+        pbFadeOutIn {
+          scene  = PokemonSummary_Scene.new
+          screen = PokemonSummaryScreen.new(scene, false)
+          screen.pbStartScreen([pkmn], 0)
+        }
+      end
+      break unless command > 1
+    end
+  end
   if $player.party_full?
     stored_box = $PokemonStorage.pbStoreCaught(pkmn)
     box_name   = $PokemonStorage[stored_box].name

--- a/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
+++ b/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
@@ -27,8 +27,8 @@ def pbStorePokemon(pkmn)
       commands = [_INTL("Add to your party"),
                   _INTL("Send to a Box"),
                   _INTL("See {1}'s summary", pkmn.name)]
-      command = pbMessage(_INTL("Where do you want to send {1} to?", pkmn.name), commands, -1)
-      if command == 0
+      case command = pbMessage(_INTL("Where do you want to send {1} to?", pkmn.name), commands, -1)
+      when 0
         pbMessage(_INTL("Please select a Pokémon to swap from your party."))
         @scene.pbChoosePokemon(1, 3)
         chosen = pbGet(1)
@@ -41,7 +41,7 @@ def pbStorePokemon(pkmn)
         pbMessage(_INTL("{1} will be added to your party, and {2} will be sent to Box \"{3}\"!",
                         pkmn_added.name, pkmn.name, box_name))
         return
-      elsif command == 2
+      when 2
         pbFadeOutIn {
           scene  = PokemonSummary_Scene.new
           screen = PokemonSummaryScreen.new(scene, false)


### PR DESCRIPTION
_G8 Option that allow you to choose what will happen with the pkm that you catch/receive._

> Not coded: You can force send to box the pkm that is being used in battle.

> Bug:  A pkm added to your party which is a higher level than required to evolve is evolving at the end of the battle.

> Note 1: I'm not much happy with the code, it just works.
> Note 2: There's a real need for the fourth choice(to see the summary of the pkm in your party)? There is a lot of text in the fourth choice, would need some text modification, and i don't see a real need for her.