### PR TITLE
More bugfixes (and one Gen 8 addition)

### DIFF
--- a/Data/Scripts/001_Settings.rb
+++ b/Data/Scripts/001_Settings.rb
@@ -177,6 +177,11 @@ module Settings
   # Whether more abilities affect whether wild Pokémon appear, which Pokémon
   # they are, etc.
   MORE_ABILITIES_AFFECT_WILD_ENCOUNTERS = (MECHANICS_GENERATION >= 8)
+  # Whether weather effects set the default terrains in battle (true) or
+  # not (false). Eg.:
+  #   * Storm weather sets Electric Terrain
+  #   * Fog weather sets Misty Terrain
+  OVERWORLD_WEATHERS_SET_TERRAINS       = (MECHANICS_GENERATION >= 8)
 
   #=============================================================================
 

--- a/Data/Scripts/007_Objects and windows/011_Messages.rb
+++ b/Data/Scripts/007_Objects and windows/011_Messages.rb
@@ -10,6 +10,7 @@ def pbMapInterpreterRunning?
   return interp&.running?
 end
 
+# Unused
 def pbRefreshSceneMap
   $scene.miniupdate if $scene.is_a?(Scene_Map)
 end

--- a/Data/Scripts/011_Battle/002_Battler/005_Battler_StatStages.rb
+++ b/Data/Scripts/011_Battle/002_Battler/005_Battler_StatStages.rb
@@ -323,9 +323,6 @@ class Battle::Battler
       @battle.pbHideAbilitySplash(self)
       return false
     end
-    if Battle::Scene::USE_ABILITY_SPLASH
-      return pbLowerStatStageByAbility(:ATTACK, 1, user, false)
-    end
     # NOTE: These checks exist to ensure appropriate messages are shown if
     #       Intimidate is blocked somehow (i.e. the messages should mention the
     #       Intimidate ability by name).
@@ -338,20 +335,25 @@ class Battle::Battler
       if abilityActive? &&
          (Battle::AbilityEffects.triggerStatLossImmunity(self.ability, self, :ATTACK, @battle, false) ||
           Battle::AbilityEffects.triggerStatLossImmunityNonIgnorable(self.ability, self, :ATTACK, @battle, false))
+        @battle.pbShowAbilitySplash(self)
         @battle.pbDisplay(_INTL("{1}'s {2} prevented {3}'s {4} from working!",
                                 pbThis, abilityName, user.pbThis(true), user.abilityName))
+        @battle.pbHideAbilitySplash(self)
         return false
       end
       allAllies.each do |b|
         next if !b.abilityActive?
         if Battle::AbilityEffects.triggerStatLossImmunityFromAlly(b.ability, b, self, :ATTACK, @battle, false)
+          @battle.pbShowAbilitySplash(self)
           @battle.pbDisplay(_INTL("{1} is protected from {2}'s {3} by {4}'s {5}!",
                                   pbThis, user.pbThis(true), user.abilityName, b.pbThis(true), b.abilityName))
+          @battle.pbHideAbilitySplash(self)
           return false
         end
       end
     end
     return false if !pbCanLowerStatStage?(:ATTACK, user)
+    return pbLowerStatStageByAbility(:ATTACK, 1, user, false) if Battle::Scene::USE_ABILITY_SPLASH
     return pbLowerStatStageByCause(:ATTACK, 1, user, user.abilityName)
   end
 

--- a/Data/Scripts/011_Battle/002_Battler/005_Battler_StatStages.rb
+++ b/Data/Scripts/011_Battle/002_Battler/005_Battler_StatStages.rb
@@ -323,6 +323,9 @@ class Battle::Battler
       @battle.pbHideAbilitySplash(self)
       return false
     end
+    if Battle::Scene::USE_ABILITY_SPLASH
+      return pbLowerStatStageByAbility(:ATTACK, 1, user, false)
+    end
     # NOTE: These checks exist to ensure appropriate messages are shown if
     #       Intimidate is blocked somehow (i.e. the messages should mention the
     #       Intimidate ability by name).
@@ -335,25 +338,20 @@ class Battle::Battler
       if abilityActive? &&
          (Battle::AbilityEffects.triggerStatLossImmunity(self.ability, self, :ATTACK, @battle, false) ||
           Battle::AbilityEffects.triggerStatLossImmunityNonIgnorable(self.ability, self, :ATTACK, @battle, false))
-        @battle.pbShowAbilitySplash(self)
         @battle.pbDisplay(_INTL("{1}'s {2} prevented {3}'s {4} from working!",
                                 pbThis, abilityName, user.pbThis(true), user.abilityName))
-        @battle.pbHideAbilitySplash(self)
         return false
       end
       allAllies.each do |b|
         next if !b.abilityActive?
         if Battle::AbilityEffects.triggerStatLossImmunityFromAlly(b.ability, b, self, :ATTACK, @battle, false)
-          @battle.pbShowAbilitySplash(self)
           @battle.pbDisplay(_INTL("{1} is protected from {2}'s {3} by {4}'s {5}!",
                                   pbThis, user.pbThis(true), user.abilityName, b.pbThis(true), b.abilityName))
-          @battle.pbHideAbilitySplash(self)
           return false
         end
       end
     end
     return false if !pbCanLowerStatStage?(:ATTACK, user)
-    return pbLowerStatStageByAbility(:ATTACK, 1, user, false) if Battle::Scene::USE_ABILITY_SPLASH
     return pbLowerStatStageByCause(:ATTACK, 1, user, user.abilityName)
   end
 

--- a/Data/Scripts/011_Battle/002_Battler/007_Battler_UseMove.rb
+++ b/Data/Scripts/011_Battle/002_Battler/007_Battler_UseMove.rb
@@ -70,7 +70,6 @@ class Battle::Battler
   #=============================================================================
   def pbBeginTurn(_choice)
     # Cancel some lingering effects which only apply until the user next moves
-    @effects[PBEffects::BeakBlast]           = false
     @effects[PBEffects::DestinyBondPrevious] = @effects[PBEffects::DestinyBond]
     @effects[PBEffects::DestinyBond]         = false
     @effects[PBEffects::Grudge]              = false

--- a/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
@@ -730,31 +730,23 @@ class PBAnimationPlayerX
     end
     # Create background colour sprite
     @bgColor = ColoredPlane.new(Color.new(0, 0, 0), @viewport)
-    @bgColor.borderX = 64 if @inEditor
-    @bgColor.borderY = 64 if @inEditor
     @bgColor.z       = 5
     @bgColor.opacity = 0
     @bgColor.refresh
     # Create background graphic sprite
     @bgGraphic = AnimatedPlane.new(@viewport)
     @bgGraphic.setBitmap(nil)
-    @bgGraphic.borderX = 64 if @inEditor
-    @bgGraphic.borderY = 64 if @inEditor
     @bgGraphic.z       = 5
     @bgGraphic.opacity = 0
     @bgGraphic.refresh
     # Create foreground colour sprite
     @foColor = ColoredPlane.new(Color.new(0, 0, 0), @viewport)
-    @foColor.borderX = 64 if @inEditor
-    @foColor.borderY = 64 if @inEditor
     @foColor.z       = 85
     @foColor.opacity = 0
     @foColor.refresh
     # Create foreground graphic sprite
     @foGraphic = AnimatedPlane.new(@viewport)
     @foGraphic.setBitmap(nil)
-    @foGraphic.borderX = 64 if @inEditor
-    @foGraphic.borderY = 64 if @inEditor
     @foGraphic.z       = 85
     @foGraphic.opacity = 0
     @foGraphic.refresh

--- a/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
+++ b/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
@@ -109,7 +109,16 @@ def pbPrepareBattle(battle)
   battle.showAnims = ($PokemonSystem.battlescene == 0)
   battle.showAnims = battleRules["battleAnims"] if !battleRules["battleAnims"].nil?
   # Terrain
-  battle.defaultTerrain = battleRules["defaultTerrain"] if !battleRules["defaultTerrain"].nil?
+  if battleRules["defaultTerrain"].nil? && Settings::MECHANICS_GENERATION >= 8
+    case $game_screen.weather_type
+    when :Storm
+      battle.defaultTerrain = :Electric
+    when :Fog
+      battle.defaultTerrain = :Misty
+    end
+  else
+    battle.defaultTerrain = battleRules["defaultTerrain"]
+  end
   # Weather
   if battleRules["defaultWeather"].nil?
     case GameData::Weather.get($game_screen.weather_type).category

--- a/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
+++ b/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
@@ -109,7 +109,7 @@ def pbPrepareBattle(battle)
   battle.showAnims = ($PokemonSystem.battlescene == 0)
   battle.showAnims = battleRules["battleAnims"] if !battleRules["battleAnims"].nil?
   # Terrain
-  if battleRules["defaultTerrain"].nil? && Settings::MECHANICS_GENERATION >= 8
+  if battleRules["defaultTerrain"].nil? && Settings::OVERWORLD_WEATHERS_SET_TERRAINS
     case $game_screen.weather_type
     when :Storm
       battle.defaultTerrain = :Electric
@@ -122,7 +122,7 @@ def pbPrepareBattle(battle)
   # Weather
   if battleRules["defaultWeather"].nil?
     case GameData::Weather.get($game_screen.weather_type).category
-    when :Rain
+    when :Rain, :Storm
       battle.defaultWeather = :Rain
     when :Hail
       battle.defaultWeather = :Hail

--- a/Data/Scripts/016_UI/015_UI_Options.rb
+++ b/Data/Scripts/016_UI/015_UI_Options.rb
@@ -352,7 +352,7 @@ class PokemonOption_Scene
     end
     pbDisposeMessageWindow(@sprites["textbox"])
     pbDisposeSpriteHash(@sprites)
-    pbRefreshSceneMap
+    pbUpdateSceneMap
     @viewport.dispose
   end
 


### PR DESCRIPTION
- Removed pbRefreshSceneMap which was only used in the Options screen
- Fixed Ability Splash setting completely negating stat blocking attempts
- Fixed Beak blast always failing because its effect would always reset at the start of the Pokemon's turn
- Fixed crash when playing an animation in the Animation Editor
- Added default terrain effects based on weather, like in Gen 8.
