### PR TITLE
Meltan + Melmetal

### DIFF
--- a/Data/Scripts/010_Data/001_Hardcoded data/007_Evolution.rb
+++ b/Data/Scripts/010_Data/001_Hardcoded data/007_Evolution.rb
@@ -555,6 +555,14 @@ GameData::Evolution.register({
   }
 })
 
+GameData::Evolution.register({
+  :id            => :ItemCandy,
+  :parameter     => Integer,
+  :use_item_proc => proc { |pkmn, parameter, item|
+    next pkmn.candies_fed >= parameter
+  }
+})
+
 #===============================================================================
 # Evolution methods that trigger when the Pokémon is obtained in a trade
 #===============================================================================

--- a/Data/Scripts/011_Battle/006_Other battle code/009_Battle_ItemEffects.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/009_Battle_ItemEffects.rb
@@ -1141,7 +1141,8 @@ Battle::ItemEffects::DamageCalcFromTarget.add(:EVIOLITE,
     #       means it also cares about the Pokémon's form. Some forms cannot
     #       evolve even if the species generally can, and such forms are not
     #       affected by Eviolite.
-    if target.pokemon.species_data.get_evolutions(true).length > 0
+    sp_data = target.pokemon.species_data
+    if sp_data.get_evolutions(true).length > 0 && !sp_data.has_flag?("UnaffectedByEviolite")
       mults[:defense_multiplier] *= 1.5
     end
   }

--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -78,6 +78,10 @@ class Pokemon
   # Used by Galarian Yamask to remember that it took sufficient damage from a
   # battle and can evolve.
   attr_accessor :ready_to_evolve
+  # Used by Meltan to store the number of Meltan Candies which have been feed
+  # to the Pokemon. This value is checked when evolving a Meltan into Melmetal.
+  # @return [Integer] amount of candies fed to Meltan
+  attr_accessor :candies_fed
   # Whether this Pokémon can be deposited in storage/Day Care
   attr_accessor :cannot_store
   # Whether this Pokémon can be released
@@ -954,6 +958,11 @@ class Pokemon
     @happiness = (@happiness + gain).clamp(0, 255)
   end
 
+  def candies_fed
+    @candies_fed = 0 if !@candies_fed
+    return @candies_fed
+  end
+
   #=============================================================================
   # Evolution checks
   #=============================================================================
@@ -1199,6 +1208,7 @@ class Pokemon
     @personalID       = rand(2**16) | (rand(2**16) << 16)
     @hp               = 1
     @totalhp          = 1
+    @candies_fed      = 0
     calc_stats
     if @form == 0 && recheck_form
       f = MultipleForms.call("getFormOnCreation", self)

--- a/PBS/items.txt
+++ b/PBS/items.txt
@@ -3158,6 +3158,14 @@ Price = 10000
 FieldUse = OnPokemon
 Description = A candy that is packed with energy. It raises the level of a single Pokémon by one.
 #-------------------------------
+[MELTANCANDY]
+Name = Meltan Candy
+NamePlural = Meltan Candies
+Pocket = 2
+Price = 20
+FieldUse = OnPokemon
+Description = A candy that is packed with energy. Feeding it to a certain Pokémon will make it evolve.
+#-------------------------------
 [MASTERBALL]
 Name = Master Ball
 NamePlural = Master Balls

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -20748,6 +20748,7 @@ Color = Gray
 Shape = Head
 Category = Hex Nut
 Pokedex = It melts particles of iron and other metals found in the subsoil, so it can absorb them into its body of molten steel.
+Flags = UnaffectedByEviolite
 Generation = 7
 Evolutions = MELMETAL,ItemCandy,400
 #-------------------------------

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -20749,7 +20749,7 @@ Shape = Head
 Category = Hex Nut
 Pokedex = It melts particles of iron and other metals found in the subsoil, so it can absorb them into its body of molten steel.
 Generation = 7
-Evolutions = MELMETAL,Level,45
+Evolutions = MELMETAL,ItemCandy,400
 #-------------------------------
 [MELMETAL]
 Name = Melmetal


### PR DESCRIPTION
This PR aims to recreate a few mechanics related to Meltan in Essentials:
- Recreated the evolution method of Meltan (feeding 400 candies to the Pokemon). 
- Added a flag which blocks the effects of Eviolite, (to prevent Meltan from being affected by Eviolite like the official games).