### PR TITLE
Add .mkproj files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ RGSS*.dll
 .vscode/
 *.code-workspace
 .idea/
+*.mkproj
 
 # Operating system generated files & folders
 .DS_Store


### PR DESCRIPTION
This PR adds .mkproj files to the .gitignore file. It should clean up the unstaged change list for those who test and/or use RPG Studio MK by Marin.