### PR TITLE
Fixing Nil and Empty String Checks

### DIFF
--- a/Data/Scripts/001_Technical/002_Files/001_FileTests.rb
+++ b/Data/Scripts/001_Technical/002_Files/001_FileTests.rb
@@ -336,7 +336,7 @@ end
 
 def pbTryString(x)
   ret = pbGetFileChar(x)
-  return (!nil_or_empty?(ret) ? x : nil)
+  return (nil_or_empty?(ret) ? nil : x)
 end
 
 # Gets the contents of a file. Doesn't check RTP, but does check

--- a/Data/Scripts/001_Technical/002_Files/001_FileTests.rb
+++ b/Data/Scripts/001_Technical/002_Files/001_FileTests.rb
@@ -279,7 +279,7 @@ end
 # and matching mount points added through System.mount
 def pbRgssExists?(filename)
   if safeExists?("./Game.rgssad")
-    return pbGetFileChar(filename) != nil
+    return !pbGetFileChar(filename).nil?
   else
     filename = canonicalize(filename)
     return safeExists?(filename)
@@ -336,7 +336,7 @@ end
 
 def pbTryString(x)
   ret = pbGetFileChar(x)
-  return (ret != nil && ret != "") ? x : nil
+  return (!nil_or_empty?(ret) ? x : nil)
 end
 
 # Gets the contents of a file. Doesn't check RTP, but does check

--- a/Data/Scripts/001_Technical/002_RubyUtilities.rb
+++ b/Data/Scripts/001_Technical/002_RubyUtilities.rb
@@ -189,6 +189,10 @@ class << Kernel
   end
 end
 
+class NilClass
+  def empty?; return true; end
+end
+
 def nil_or_empty?(string)
   return string.nil? || !string.is_a?(String) || string.size == 0
 end

--- a/Data/Scripts/001_Technical/003_Intl_Messages.rb
+++ b/Data/Scripts/001_Technical/003_Intl_Messages.rb
@@ -682,9 +682,7 @@ module MessageTypes
 
   def self.get(type, id)
     ret = @@messages.get(type, id)
-    if ret == ""
-      ret = @@messagesFallback.get(type, id)
-    end
+    ret = @@messagesFallback.get(type, id) if nil_or_empty?(ret)
     return ret
   end
 

--- a/Data/Scripts/001_Technical/003_Intl_Messages.rb
+++ b/Data/Scripts/001_Technical/003_Intl_Messages.rb
@@ -61,7 +61,7 @@ def pbSetTextMessages
         event.list.size.times do |j|
           list = event.list[j]
           if neednewline && list.code != 401
-            if lastitem != ""
+            if !lastitem.empty?
               lastitem.gsub!(/([^\.\!\?])\s\s+/) { |m| $1 + " " }
               items.push(lastitem)
               lastitem = ""
@@ -77,7 +77,7 @@ def pbSetTextMessages
             end
             neednewline = false
           elsif list.code == 401
-            lastitem += " " if lastitem != ""
+            lastitem += " " if !lastitem.empty?
             lastitem += list.parameters[0].to_s
             neednewline = true
           elsif list.code == 355 || list.code == 655
@@ -93,7 +93,7 @@ def pbSetTextMessages
             end
           end
         end
-        if neednewline && lastitem != ""
+        if neednewline && !lastitem.empty?
           items.push(lastitem)
           lastitem = ""
         end
@@ -130,7 +130,7 @@ def pbSetTextMessages
             event.pages[i].list.size.times do |j|
               list = event.pages[i].list[j]
               if neednewline && list.code != 401
-                if lastitem != ""
+                if !lastitem.empty?
                   lastitem.gsub!(/([^\.\!\?])\s\s+/) { |m| $1 + " " }
                   items.push(lastitem)
                   lastitem = ""
@@ -146,7 +146,7 @@ def pbSetTextMessages
                 end
                 neednewline = false
               elsif list.code == 401
-                lastitem += " " if lastitem != ""
+                lastitem += " " if !lastitem.empty?
                 lastitem += list.parameters[0].to_s
                 neednewline = true
               elsif list.code == 355 || list.code == 655
@@ -162,7 +162,7 @@ def pbSetTextMessages
                 end
               end
             end
-            if neednewline && lastitem != ""
+            if neednewline && !lastitem.empty?
               items.push(lastitem)
               lastitem = ""
             end
@@ -235,7 +235,7 @@ def pbGetText(infile)
       if !name[/^([Mm][Aa][Pp])?(\d+)$/]
         raise _INTL("Invalid section name {1}", name)
       end
-      ismap = $~[1] && $~[1] != ""
+      ismap = $~[1] && !$~[1].empty?
       id = $~[2].to_i
       itemlength = 0
       if section[0][/^\d+$/]

--- a/Data/Scripts/001_Technical/005_PluginManager.rb
+++ b/Data/Scripts/001_Technical/005_PluginManager.rb
@@ -571,7 +571,7 @@ module PluginManager
       dname = dname[0] if dname.is_a?(Array) && dname.length == 2
       dname = dname[1] if dname.is_a?(Array) && dname.length == 3
       # catch looping dependency issue
-      self.error("Plugin '#{og[0]}' has looping dependencies which cannot be resolved automatically.") if !og.nil? && og.include?(dname)
+      self.error("Plugin '#{og[0]}' has looping dependencies which cannot be resolved automatically.") if og&.include?(dname)
       new_og = og.clone
       new_og.push(dname)
       self.validateDependencies(dname, meta, new_og)

--- a/Data/Scripts/001_Technical/006_RPG_Sprite.rb
+++ b/Data/Scripts/001_Technical/006_RPG_Sprite.rb
@@ -90,11 +90,9 @@ class SpriteAnimation
   def dispose_animation
     return if @_animation_sprites.nil?
     sprite = @_animation_sprites[0]
-    if !sprite.nil?
+    if sprite
       @@_reference_count[sprite.bitmap] -= 1
-      if @@_reference_count[sprite.bitmap] == 0
-        sprite.bitmap.dispose
-      end
+      sprite.bitmap.dispose if @@_reference_count[sprite.bitmap] == 0
     end
     @_animation_sprites.each do |sprite|
       sprite.dispose
@@ -106,7 +104,7 @@ class SpriteAnimation
   def dispose_loop_animation
     return if @_loop_animation_sprites.nil?
     sprite = @_loop_animation_sprites[0]
-    if !sprite.nil?
+    if sprite
       @@_reference_count[sprite.bitmap] -= 1
       sprite.bitmap.dispose if @@_reference_count[sprite.bitmap] == 0
     end
@@ -118,7 +116,7 @@ class SpriteAnimation
   end
 
   def active?
-    return !@_loop_animation_sprites.nil? || !@_animation_sprites.nil?
+    return !(@_loop_animation_sprites.nil? && @_animation_sprites.nil?)
   end
 
   def effect?
@@ -126,7 +124,7 @@ class SpriteAnimation
   end
 
   def update
-    if !@_animation.nil?
+    if @_animation
       quick_update = true
       if Graphics.frame_count % @_animation_frame_skip == 0
         @_animation_duration -= 1
@@ -134,7 +132,7 @@ class SpriteAnimation
       end
       update_animation(quick_update)
     end
-    if !@_loop_animation.nil?
+    if @_loop_animation
       quick_update = (Graphics.frame_count % @_loop_animation_frame_skip != 0)
       update_loop_animation(quick_update)
       if !quick_update
@@ -176,7 +174,7 @@ class SpriteAnimation
     sprite_x = 320
     sprite_y = 240
     if position == 3
-      if !self.viewport.nil?
+      if self.viewport
         sprite_x = self.viewport.rect.width / 2
         sprite_y = self.viewport.rect.height - 160
       end
@@ -190,7 +188,7 @@ class SpriteAnimation
       sprite = sprites[i]
       pattern = cell_data[i, 0]
       if sprite.nil? || pattern.nil? || pattern == -1
-        sprite.visible = false if !sprite.nil?
+        sprite.visible = false if sprite
         next
       end
       sprite.x = sprite_x + cell_data[i, 1]
@@ -238,15 +236,15 @@ class SpriteAnimation
   def x=(x)
     sx = x - self.x
     return if sx == 0
-    16.times { |i| @_animation_sprites[i].x += sx } if !@_animation_sprites.nil?
-    16.times { |i| @_loop_animation_sprites[i].x += sx } if !@_loop_animation_sprites.nil?
+    16.times { |i| @_animation_sprites[i].x += sx } if @_animation_sprites
+    16.times { |i| @_loop_animation_sprites[i].x += sx } if @_loop_animation_sprites
   end
 
   def y=(y)
     sy = y - self.y
     return if sy == 0
-    16.times { |i| @_animation_sprites[i].y += sy } if !@_animation_sprites.nil?
-    16.times { |i| @_loop_animation_sprites[i].y += sy } if !@_loop_animation_sprites.nil?
+    16.times { |i| @_animation_sprites[i].y += sy } if @_animation_sprites
+    16.times { |i| @_loop_animation_sprites[i].y += sy } if @_loop_animation_sprites
   end
 end
 

--- a/Data/Scripts/001_Technical/006_RPG_Sprite.rb
+++ b/Data/Scripts/001_Technical/006_RPG_Sprite.rb
@@ -53,9 +53,7 @@ class SpriteAnimation
         sprite.visible = false
         @_animation_sprites.push(sprite)
       end
-      unless @@_animations.include?(animation)
-        @@_animations.push(animation)
-      end
+      @@_animations.push(animation) if !@@_animations.include?(animation)
     end
     update_animation
   end
@@ -92,7 +90,7 @@ class SpriteAnimation
   def dispose_animation
     return if @_animation_sprites.nil?
     sprite = @_animation_sprites[0]
-    if sprite != nil
+    if !sprite.nil?
       @@_reference_count[sprite.bitmap] -= 1
       if @@_reference_count[sprite.bitmap] == 0
         sprite.bitmap.dispose
@@ -108,11 +106,9 @@ class SpriteAnimation
   def dispose_loop_animation
     return if @_loop_animation_sprites.nil?
     sprite = @_loop_animation_sprites[0]
-    if sprite != nil
+    if !sprite.nil?
       @@_reference_count[sprite.bitmap] -= 1
-      if @@_reference_count[sprite.bitmap] == 0
-        sprite.bitmap.dispose
-      end
+      sprite.bitmap.dispose if @@_reference_count[sprite.bitmap] == 0
     end
     @_loop_animation_sprites.each do |sprite|
       sprite.dispose
@@ -122,7 +118,7 @@ class SpriteAnimation
   end
 
   def active?
-    return @_loop_animation_sprites != nil || @_animation_sprites != nil
+    return !@_loop_animation_sprites.nil? || !@_animation_sprites.nil?
   end
 
   def effect?
@@ -130,7 +126,7 @@ class SpriteAnimation
   end
 
   def update
-    if @_animation != nil
+    if !@_animation.nil?
       quick_update = true
       if Graphics.frame_count % @_animation_frame_skip == 0
         @_animation_duration -= 1
@@ -138,7 +134,7 @@ class SpriteAnimation
       end
       update_animation(quick_update)
     end
-    if @_loop_animation != nil
+    if !@_loop_animation.nil?
       quick_update = (Graphics.frame_count % @_loop_animation_frame_skip != 0)
       update_loop_animation(quick_update)
       if !quick_update
@@ -180,7 +176,7 @@ class SpriteAnimation
     sprite_x = 320
     sprite_y = 240
     if position == 3
-      if self.viewport != nil
+      if !self.viewport.nil?
         sprite_x = self.viewport.rect.width / 2
         sprite_y = self.viewport.rect.height - 160
       end
@@ -194,7 +190,7 @@ class SpriteAnimation
       sprite = sprites[i]
       pattern = cell_data[i, 0]
       if sprite.nil? || pattern.nil? || pattern == -1
-        sprite.visible = false if sprite != nil
+        sprite.visible = false if !sprite.nil?
         next
       end
       sprite.x = sprite_x + cell_data[i, 1]
@@ -232,9 +228,7 @@ class SpriteAnimation
       when 1
         self.flash(timing.flash_color, timing.flash_duration * 2)
       when 2
-        if self.viewport != nil
-          self.viewport.flash(timing.flash_color, timing.flash_duration * 2)
-        end
+        self.viewport&.flash(timing.flash_color, timing.flash_duration * 2)
       when 3
         self.flash(nil, timing.flash_duration * 2)
       end
@@ -244,31 +238,15 @@ class SpriteAnimation
   def x=(x)
     sx = x - self.x
     return if sx == 0
-    if @_animation_sprites != nil
-      16.times do |i|
-        @_animation_sprites[i].x += sx
-      end
-    end
-    if @_loop_animation_sprites != nil
-      16.times do |i|
-        @_loop_animation_sprites[i].x += sx
-      end
-    end
+    16.times { |i| @_animation_sprites[i].x += sx } if !@_animation_sprites.nil?
+    16.times { |i| @_loop_animation_sprites[i].x += sx } if !@_loop_animation_sprites.nil?
   end
 
   def y=(y)
     sy = y - self.y
     return if sy == 0
-    if @_animation_sprites != nil
-      16.times do |i|
-        @_animation_sprites[i].y += sy
-      end
-    end
-    if @_loop_animation_sprites != nil
-      16.times do |i|
-        @_loop_animation_sprites[i].y += sy
-      end
-    end
+    16.times { |i| @_animation_sprites[i].y += sy } if !@_animation_sprites.nil?
+    16.times { |i| @_loop_animation_sprites[i].y += sy } if !@_loop_animation_sprites.nil?
   end
 end
 

--- a/Data/Scripts/001_Technical/006_RPG_Sprite.rb
+++ b/Data/Scripts/001_Technical/006_RPG_Sprite.rb
@@ -220,7 +220,7 @@ class SpriteAnimation
     if timing.condition == 0 ||
        (timing.condition == 1 && hit == true) ||
        (timing.condition == 2 && hit == false)
-      if timing.se.name != ""
+      if !timing.se.name.empty?
         se = timing.se
         pbSEPlay(se)
       end

--- a/Data/Scripts/003_Game processing/002_Scene_Map.rb
+++ b/Data/Scripts/003_Game processing/002_Scene_Map.rb
@@ -179,7 +179,7 @@ class Scene_Map
     end
     if $game_temp.transition_processing
       $game_temp.transition_processing = false
-      if $game_temp.transition_name == ""
+      if $game_temp.transition_name.empty?
         Graphics.transition
       else
         Graphics.transition(40, "Graphics/Transitions/" + $game_temp.transition_name)

--- a/Data/Scripts/003_Game processing/003_Interpreter.rb
+++ b/Data/Scripts/003_Game processing/003_Interpreter.rb
@@ -79,9 +79,7 @@ class Interpreter
     end
   end
 
-  def running?
-    return @list != nil
-  end
+  def running?; return !@list.nil?; end
   #-----------------------------------------------------------------------------
   # * Frame Update
   #-----------------------------------------------------------------------------

--- a/Data/Scripts/003_Game processing/004_Interpreter_Commands.rb
+++ b/Data/Scripts/003_Game processing/004_Interpreter_Commands.rb
@@ -168,7 +168,7 @@ class Interpreter
       case @list[next_index].code
       when 401   # Continuation of 101 Show Text
         text = @list[next_index].parameters[0]
-        message += " " if text != "" && message[message.length - 1, 1] != " "
+        message += " " if !text.empty? && message[message.length - 1, 1] != " "
         message += text
         @index = next_index
         next

--- a/Data/Scripts/003_Game processing/004_Interpreter_Commands.rb
+++ b/Data/Scripts/003_Game processing/004_Interpreter_Commands.rb
@@ -1019,7 +1019,7 @@ class Interpreter
       $player.name = pbEnterPlayerName(_INTL("Your name?"), 1, @parameters[1], $player.name)
       return true
     end
-    if $game_actors && $data_actors && $data_actors[@parameters[0]] != nil
+    if $game_actors && $data_actors && !$data_actors[@parameters[0]].nil?
       $game_temp.battle_abort = true
       pbFadeOutIn {
         sscene = PokemonEntryScene.new

--- a/Data/Scripts/003_Game processing/005_Event_Handlers.rb
+++ b/Data/Scripts/003_Game processing/005_Event_Handlers.rb
@@ -142,11 +142,7 @@ class HandlerHash
 
   def copy(src, *dests)
     handler = self[src]
-    if handler
-      dests.each do |dest|
-        self.add(dest, handler)
-      end
-    end
+    dests.each { |dest| self.add(dest, handler) } if handler
   end
 
   def [](sym)   # 'sym' can be an ID or symbol
@@ -155,11 +151,7 @@ class HandlerHash
     ret = @hash[id] if id && @hash[id]   # Real ID from the item
     symbol = toSymbol(sym)
     ret = @hash[symbol] if symbol && @hash[symbol]   # Symbol or string
-    unless ret
-      @addIfs.each do |addif|
-        return addif[1] if addif[0].call(id)
-      end
-    end
+    @addIfs.each { |addif| return addif[1] if addif[0].call(id) } if !ret
     return ret
   end
 
@@ -187,9 +179,7 @@ class HandlerHash2
   def [](sym)
     sym = sym.id if !sym.is_a?(Symbol) && sym.respond_to?("id")
     return @hash[sym] if sym && @hash[sym]
-    @add_ifs.each do |add_if|
-      return add_if[1] if add_if[0].call(sym)
-    end
+    @add_ifs.each { |add_if| return add_if[1] if add_if[0].call(sym) }
     return nil
   end
 
@@ -241,11 +231,7 @@ class HandlerHashBasic
   def [](entry)
     ret = nil
     ret = @hash[entry] if entry && @hash[entry]
-    unless ret
-      @addIfs.each do |addif|
-        return addif[1] if addif[0].call(entry)
-      end
-    end
+    @addIfs.each { |addif| return addif[1] if addif[0].call(entry) } if !ret
     return ret
   end
 

--- a/Data/Scripts/003_Game processing/005_Event_Handlers.rb
+++ b/Data/Scripts/003_Game processing/005_Event_Handlers.rb
@@ -151,7 +151,7 @@ class HandlerHash
     ret = @hash[id] if id && @hash[id]   # Real ID from the item
     symbol = toSymbol(sym)
     ret = @hash[symbol] if symbol && @hash[symbol]   # Symbol or string
-    @addIfs.each { |addif| return addif[1] if addif[0].call(id) } if !ret
+    @addIfs.each { |addif| return addif[1] if addif[0].call(id) } unless ret
     return ret
   end
 
@@ -231,7 +231,7 @@ class HandlerHashBasic
   def [](entry)
     ret = nil
     ret = @hash[entry] if entry && @hash[entry]
-    @addIfs.each { |addif| return addif[1] if addif[0].call(entry) } if !ret
+    @addIfs.each { |addif| return addif[1] if addif[0].call(entry) } unless ret
     return ret
   end
 

--- a/Data/Scripts/004_Game classes/001_Switches and Variables/002_Game_Switches.rb
+++ b/Data/Scripts/004_Game classes/001_Switches and Variables/002_Game_Switches.rb
@@ -16,7 +16,7 @@ class Game_Switches
   #     switch_id : switch ID
   #-----------------------------------------------------------------------------
   def [](switch_id)
-    return @data[switch_id] if switch_id <= 5000 && @data[switch_id] != nil
+    return @data[switch_id] if switch_id <= 5000 && !@data[switch_id].nil?
     return false
   end
   #-----------------------------------------------------------------------------

--- a/Data/Scripts/004_Game classes/002_Game_System.rb
+++ b/Data/Scripts/004_Game classes/002_Game_System.rb
@@ -62,7 +62,7 @@ class Game_System
   def bgm_play_internal(bgm, position) # :nodoc:
     @bgm_position = position if !@bgm_paused
     @playing_bgm = bgm&.clone
-    if bgm != nil && bgm.name != ""
+    if !bgm.nil? && bgm.name != ""
       if !@defaultBGM && FileTest.audio_exist?("Audio/BGM/" + bgm.name)
         bgm_play_internal2("Audio/BGM/" + bgm.name, bgm.volume, bgm.pitch, @bgm_position)
       end
@@ -132,7 +132,7 @@ class Game_System
   def setDefaultBGM(bgm, volume = 80, pitch = 100)
     bgm = RPG::AudioFile.new(bgm, volume, pitch) if bgm.is_a?(String)
     @defaultBGM = nil
-    if bgm != nil && bgm.name != ""
+    if !bgm.nil? && bgm.name != ""
       self.bgm_play(bgm)
       @defaultBGM = bgm.clone
     else
@@ -144,7 +144,7 @@ class Game_System
 
   def me_play(me)
     me = RPG::AudioFile.new(me) if me.is_a?(String)
-    if me != nil && me.name != ""
+    if !me.nil? && me.name != ""
       if FileTest.audio_exist?("Audio/ME/" + me.name)
         vol = me.volume
         vol *= $PokemonSystem.bgmvolume / 100.0
@@ -161,7 +161,7 @@ class Game_System
 
   def bgs_play(bgs)
     @playing_bgs = (bgs.nil?) ? nil : bgs.clone
-    if bgs != nil && bgs.name != ""
+    if !bgs.nil? && bgs.name != ""
       if FileTest.audio_exist?("Audio/BGS/" + bgs.name)
         vol = bgs.volume
         vol *= $PokemonSystem.sevolume / 100.0
@@ -228,7 +228,7 @@ class Game_System
 
   def se_play(se)
     se = RPG::AudioFile.new(se) if se.is_a?(String)
-    if se != nil && se.name != "" && FileTest.audio_exist?("Audio/SE/" + se.name)
+    if !se.nil? && se.name != "" && FileTest.audio_exist?("Audio/SE/" + se.name)
       vol = se.volume
       vol *= $PokemonSystem.sevolume / 100.0
       vol = vol.to_i

--- a/Data/Scripts/004_Game classes/002_Game_System.rb
+++ b/Data/Scripts/004_Game classes/002_Game_System.rb
@@ -62,7 +62,7 @@ class Game_System
   def bgm_play_internal(bgm, position) # :nodoc:
     @bgm_position = position if !@bgm_paused
     @playing_bgm = bgm&.clone
-    if !bgm.nil? && bgm.name != ""
+    if !nil_or_empty?(bgm&.name)
       if !@defaultBGM && FileTest.audio_exist?("Audio/BGM/" + bgm.name)
         bgm_play_internal2("Audio/BGM/" + bgm.name, bgm.volume, bgm.pitch, @bgm_position)
       end
@@ -132,7 +132,7 @@ class Game_System
   def setDefaultBGM(bgm, volume = 80, pitch = 100)
     bgm = RPG::AudioFile.new(bgm, volume, pitch) if bgm.is_a?(String)
     @defaultBGM = nil
-    if !bgm.nil? && bgm.name != ""
+    if !nil_or_empty?(bgm&.name)
       self.bgm_play(bgm)
       @defaultBGM = bgm.clone
     else
@@ -144,7 +144,7 @@ class Game_System
 
   def me_play(me)
     me = RPG::AudioFile.new(me) if me.is_a?(String)
-    if !me.nil? && me.name != ""
+    if !nil_or_empty?(me&.name)
       if FileTest.audio_exist?("Audio/ME/" + me.name)
         vol = me.volume
         vol *= $PokemonSystem.bgmvolume / 100.0
@@ -161,7 +161,7 @@ class Game_System
 
   def bgs_play(bgs)
     @playing_bgs = (bgs.nil?) ? nil : bgs.clone
-    if !bgs.nil? && bgs.name != ""
+    if !nil_or_empty?(bgs&.name)
       if FileTest.audio_exist?("Audio/BGS/" + bgs.name)
         vol = bgs.volume
         vol *= $PokemonSystem.sevolume / 100.0
@@ -228,7 +228,7 @@ class Game_System
 
   def se_play(se)
     se = RPG::AudioFile.new(se) if se.is_a?(String)
-    if !se.nil? && se.name != "" && FileTest.audio_exist?("Audio/SE/" + se.name)
+    if !nil_or_empty?(se&.name) && FileTest.audio_exist?("Audio/SE/" + se.name)
       vol = se.volume
       vol *= $PokemonSystem.sevolume / 100.0
       vol = vol.to_i

--- a/Data/Scripts/004_Game classes/002_Game_System.rb
+++ b/Data/Scripts/004_Game classes/002_Game_System.rb
@@ -62,10 +62,9 @@ class Game_System
   def bgm_play_internal(bgm, position) # :nodoc:
     @bgm_position = position if !@bgm_paused
     @playing_bgm = bgm&.clone
-    if !nil_or_empty?(bgm&.name)
-      if !@defaultBGM && FileTest.audio_exist?("Audio/BGM/" + bgm.name)
-        bgm_play_internal2("Audio/BGM/" + bgm.name, bgm.volume, bgm.pitch, @bgm_position)
-      end
+    if !nil_or_empty?(bgm&.name) && !@defaultBGM &&
+       FileTest.audio_exist?("Audio/BGM/" + bgm.name)
+      bgm_play_internal2("Audio/BGM/" + bgm.name, bgm.volume, bgm.pitch, @bgm_position)
     else
       @bgm_position = position if !@bgm_paused
       @playing_bgm = nil
@@ -132,11 +131,11 @@ class Game_System
   def setDefaultBGM(bgm, volume = 80, pitch = 100)
     bgm = RPG::AudioFile.new(bgm, volume, pitch) if bgm.is_a?(String)
     @defaultBGM = nil
-    if !nil_or_empty?(bgm&.name)
+    if nil_or_empty?(bgm&.name)
+      self.bgm_play(@playing_bgm)
+    else
       self.bgm_play(bgm)
       @defaultBGM = bgm.clone
-    else
-      self.bgm_play(@playing_bgm)
     end
   end
 
@@ -144,13 +143,11 @@ class Game_System
 
   def me_play(me)
     me = RPG::AudioFile.new(me) if me.is_a?(String)
-    if !nil_or_empty?(me&.name)
-      if FileTest.audio_exist?("Audio/ME/" + me.name)
-        vol = me.volume
-        vol *= $PokemonSystem.bgmvolume / 100.0
-        vol = vol.to_i
-        Audio.me_play("Audio/ME/" + me.name, vol, me.pitch)
-      end
+    if !nil_or_empty?(me&.name) && FileTest.audio_exist?("Audio/ME/" + me.name)
+      vol = me.volume
+      vol *= $PokemonSystem.bgmvolume / 100.0
+      vol = vol.to_i
+      Audio.me_play("Audio/ME/" + me.name, vol, me.pitch)
     else
       Audio.me_stop
     end
@@ -161,13 +158,11 @@ class Game_System
 
   def bgs_play(bgs)
     @playing_bgs = (bgs.nil?) ? nil : bgs.clone
-    if !nil_or_empty?(bgs&.name)
-      if FileTest.audio_exist?("Audio/BGS/" + bgs.name)
-        vol = bgs.volume
-        vol *= $PokemonSystem.sevolume / 100.0
-        vol = vol.to_i
-        Audio.bgs_play("Audio/BGS/" + bgs.name, vol, bgs.pitch)
-      end
+    if !nil_or_empty?(bgs&.name) && FileTest.audio_exist?("Audio/BGS/" + bgs.name)
+      vol = bgs.volume
+      vol *= $PokemonSystem.sevolume / 100.0
+      vol = vol.to_i
+      Audio.bgs_play("Audio/BGS/" + bgs.name, vol, bgs.pitch)
     else
       @bgs_position = 0
       @playing_bgs  = nil

--- a/Data/Scripts/004_Game classes/004_Game_Map.rb
+++ b/Data/Scripts/004_Game classes/004_Game_Map.rb
@@ -190,7 +190,7 @@ class Game_Map
       tile_id = data[x, y, i]
       terrain = GameData::TerrainTag.try_get(@terrain_tags[tile_id])
       # If already on water, only allow movement to another water tile
-      if !self_event.nil? && terrain.can_surf_freely
+      if self_event && terrain.can_surf_freely
         [2, 1, 0].each do |j|
           facing_tile_id = data[newx, newy, j]
           return false if facing_tile_id.nil?
@@ -203,7 +203,7 @@ class Game_Map
       # Can't walk onto ice
       elsif terrain.ice
         return false
-      elsif !self_event.nil? && self_event.x == x && self_event.y == y
+      elsif self_event && self_event.x == x && self_event.y == y
         # Can't walk onto ledges
         [2, 1, 0].each do |j|
           facing_tile_id = data[newx, newy, j]

--- a/Data/Scripts/004_Game classes/004_Game_Map.rb
+++ b/Data/Scripts/004_Game classes/004_Game_Map.rb
@@ -190,7 +190,7 @@ class Game_Map
       tile_id = data[x, y, i]
       terrain = GameData::TerrainTag.try_get(@terrain_tags[tile_id])
       # If already on water, only allow movement to another water tile
-      if self_event != nil && terrain.can_surf_freely
+      if !self_event.nil? && terrain.can_surf_freely
         [2, 1, 0].each do |j|
           facing_tile_id = data[newx, newy, j]
           return false if facing_tile_id.nil?
@@ -203,7 +203,7 @@ class Game_Map
       # Can't walk onto ice
       elsif terrain.ice
         return false
-      elsif self_event != nil && self_event.x == x && self_event.y == y
+      elsif !self_event.nil? && self_event.x == x && self_event.y == y
         # Can't walk onto ledges
         [2, 1, 0].each do |j|
           facing_tile_id = data[newx, newy, j]

--- a/Data/Scripts/004_Game classes/005_Game_Map_Autoscroll.rb
+++ b/Data/Scripts/004_Game classes/005_Game_Map_Autoscroll.rb
@@ -126,7 +126,7 @@ class Interpreter
       end
       count = [count_x.abs, count_y.abs].min
     end
-    $game_map.start_scroll(dir, count, speed) if !dir.nil?
+    $game_map.start_scroll(dir, count, speed) if dir
     if @diag
       return false
     else

--- a/Data/Scripts/004_Game classes/005_Game_Map_Autoscroll.rb
+++ b/Data/Scripts/004_Game classes/005_Game_Map_Autoscroll.rb
@@ -126,7 +126,7 @@ class Interpreter
       end
       count = [count_x.abs, count_y.abs].min
     end
-    $game_map.start_scroll(dir, count, speed) if dir != nil
+    $game_map.start_scroll(dir, count, speed) if !dir.nil?
     if @diag
       return false
     else

--- a/Data/Scripts/004_Game classes/006_Game_MapFactory.rb
+++ b/Data/Scripts/004_Game classes/006_Game_MapFactory.rb
@@ -182,12 +182,12 @@ class PokemonMapFactory
     # Check passability of event(s) in that spot
     map.events.values.each do |event|
       next if event == thisEvent || !event.at_coordinate?(x, y)
-      return false if !event.through && event.character_name != ""
+      return false if !event.through && !event.character_name.empty?
     end
     # Check passability of player
     if !thisEvent.is_a?(Game_Player) &&
        $game_map.map_id == mapID && $game_player.x == x && $game_player.y == y &&
-       !$game_player.through && $game_player.character_name != ""
+       !$game_player.through && !$game_player.character_name.empty?
       return false
     end
     return true
@@ -209,7 +209,7 @@ class PokemonMapFactory
     end
     map.events.values.each do |event|
       next if event == thisEvent || !event.at_coordinate?(x, y)
-      return false if !event.through && event.character_name != ""
+      return false if !event.through && !event.character_name.empty?
     end
     return true
   end

--- a/Data/Scripts/004_Game classes/007_Game_Character.rb
+++ b/Data/Scripts/004_Game classes/007_Game_Character.rb
@@ -242,10 +242,10 @@ class Game_Character
     end
     self.map.events.values.each do |event|
       next if self == event || !event.at_coordinate?(new_x, new_y) || event.through
-      return false if self != $game_player || event.character_name != ""
+      return false if self != $game_player || !event.character_name.empty?
     end
     if $game_player.x == new_x && $game_player.y == new_y &&
-       !$game_player.through && @character_name != ""
+       !$game_player.through && !@character_name.empty?
       return false
     end
     return true

--- a/Data/Scripts/004_Game classes/008_Game_Event.rb
+++ b/Data/Scripts/004_Game classes/008_Game_Event.rb
@@ -269,7 +269,7 @@ class Game_Event < Game_Character
       refresh
     end
     check_event_trigger_auto
-    if !@interpreter.nil?
+    if @interpreter
       @interpreter.setup(@list, @event.id, @map_id) if !@interpreter.running?
       @interpreter.update
     end

--- a/Data/Scripts/004_Game classes/008_Game_Event.rb
+++ b/Data/Scripts/004_Game classes/008_Game_Event.rb
@@ -131,7 +131,7 @@ class Game_Event < Game_Character
   end
 
   def over_trigger?
-    return false if @character_name != "" && !@through
+    return false if !@character_name.empty? && !@through
     return false if @event.name[/hiddenitem/i]
     each_occupied_tile do |i, j|
       return true if self.map.passable?(i, j, 0, $game_player)

--- a/Data/Scripts/004_Game classes/008_Game_Event.rb
+++ b/Data/Scripts/004_Game classes/008_Game_Event.rb
@@ -269,10 +269,8 @@ class Game_Event < Game_Character
       refresh
     end
     check_event_trigger_auto
-    if @interpreter != nil
-      unless @interpreter.running?
-        @interpreter.setup(@list, @event.id, @map_id)
-      end
+    if !@interpreter.nil?
+      @interpreter.setup(@list, @event.id, @map_id) if !@interpreter.running?
       @interpreter.update
     end
   end

--- a/Data/Scripts/004_Game classes/010_Game_CommonEvent.rb
+++ b/Data/Scripts/004_Game classes/010_Game_CommonEvent.rb
@@ -68,14 +68,10 @@ class Game_CommonEvent
   #-----------------------------------------------------------------------------
   def update
     # If parallel process is valid
-    if @interpreter != nil
-      # If not running
-      unless @interpreter.running?
-        # Set up event
-        @interpreter.setup(self.list, 0)
-      end
-      # Update interpreter
-      @interpreter.update
-    end
+    return if @interpreter.nil?
+    # Set up event if not running
+    @interpreter.setup(self.list, 0) if !@interpreter.running?
+    # Update interpreter
+    @interpreter.update
   end
 end

--- a/Data/Scripts/004_Game classes/011_Game_Follower.rb
+++ b/Data/Scripts/004_Game classes/011_Game_Follower.rb
@@ -196,7 +196,7 @@ class Game_Follower < Game_Event
     # Check all events on the map to see if any are in the way
     this_map.events.values.each do |event|
       next if !event.at_coordinate?(x, y)
-      return false if !event.through && event.character_name != ""
+      return false if !event.through && !event.character_name.empty?
     end
     return true
   end

--- a/Data/Scripts/005_Sprites/001_Sprite_Picture.rb
+++ b/Data/Scripts/005_Sprites/001_Sprite_Picture.rb
@@ -17,14 +17,14 @@ class Sprite_Picture
       # Remember file name to instance variables
       @picture_name = @picture.name
       # If file name is not empty
-      if @picture_name != ""
+      if !@picture_name.empty?
         # Get picture graphic
         @sprite = IconSprite.new(0, 0, @viewport) if !@sprite
         @sprite.setBitmap("Graphics/Pictures/" + @picture_name)
       end
     end
     # If file name is empty
-    if @picture_name == ""
+    if @picture_name.empty?
       # Set sprite to invisible
       if @sprite
         @sprite&.dispose

--- a/Data/Scripts/005_Sprites/009_Sprite_DynamicShadows.rb
+++ b/Data/Scripts/005_Sprites/009_Sprite_DynamicShadows.rb
@@ -134,11 +134,7 @@ class Sprite_Character < RPG::Sprite
   def setShadows(map, shadows)
     if character.is_a?(Game_Event) && shadows.length > 0
       params = XPML_read(map, "Shadow", @character, 4)
-      if params != nil
-        shadows.each do |shadow|
-          @ombrelist.push(Sprite_Shadow.new(viewport, @character, shadows))
-        end
-      end
+      shadows.each { |shadow| @ombrelist.push(Sprite_Shadow.new(viewport, @character, shadows)) } unless params.nil?
     end
     if character.is_a?(Game_Player) && shadows.length > 0
       shadows.each do |shadow|
@@ -186,10 +182,10 @@ class Spriteset_Map
     map = $game_map if !map
     map.events.keys.sort.each do |k|
       ev = map.events[k]
-      warn = true if ev.list != nil && ev.list.length > 0 && ev.list[0].code == 108 &&
+      warn = true if !ev.list.nil? && ev.list.length > 0 && ev.list[0].code == 108 &&
                      (ev.list[0].parameters == ["s"] || ev.list[0].parameters == ["o"])
       params = XPML_read(map, "Shadow Source", ev, 4)
-      @shadows.push([ev] + params) if params != nil
+      @shadows.push([ev] + params) unless params.nil?
     end
     if warn == true
       p "Warning : At least one event on this map uses the obsolete way to add shadows"

--- a/Data/Scripts/005_Sprites/009_Sprite_DynamicShadows.rb
+++ b/Data/Scripts/005_Sprites/009_Sprite_DynamicShadows.rb
@@ -221,7 +221,7 @@ end
 #===================================================
 def XPML_read(map, markup, event, max_param_number = 0)
   parameter_list = nil
-  return nil if !event || event.list.nil?
+  return nil if event&.list.nil?
   event.list.size.times do |i|
     if event.list[i].code == 108 &&
        event.list[i].parameters[0].downcase == "begin " + markup.downcase

--- a/Data/Scripts/005_Sprites/013_ScreenPosHelper.rb
+++ b/Data/Scripts/005_Sprites/013_ScreenPosHelper.rb
@@ -33,7 +33,7 @@ module ScreenPosHelper
       height = 0
       if ch.tile_id > 0
         height = 32
-      elsif ch.character_name != ""
+      elsif !ch.character_name.empty?
         height = bmHeight(ch.character_name) / 4
       end
     end

--- a/Data/Scripts/007_Objects and windows/001_RPG_Cache.rb
+++ b/Data/Scripts/007_Objects and windows/001_RPG_Cache.rb
@@ -36,7 +36,7 @@ module RPG
       cached = true
       ret = fromCache(path)
       if !ret
-        if filename == ""
+        if filename.empty?
           ret = BitmapWrapper.new(32, 32)
         else
           ret = BitmapWrapper.new(path)

--- a/Data/Scripts/007_Objects and windows/002_MessageConfig.rb
+++ b/Data/Scripts/007_Objects and windows/002_MessageConfig.rb
@@ -130,17 +130,17 @@ module MessageConfig
 
   def self.pbSetSystemFontName(value)
     @@systemFont = MessageConfig.pbTryFonts(value)
-    @@systemFont = MessageConfig.pbDefaultSystemFontName if @@systemFont == ""
+    @@systemFont = MessageConfig.pbDefaultSystemFontName if @@systemFont.empty?
   end
 
   def self.pbSetSmallFontName(value)
     @@smallFont = MessageConfig.pbTryFonts(value)
-    @@smallFont = MessageConfig.pbDefaultSmallFontName if @@smallFont == ""
+    @@smallFont = MessageConfig.pbDefaultSmallFontName if @@smallFont.empty?
   end
 
   def self.pbSetNarrowFontName(value)
     @@narrowFont = MessageConfig.pbTryFonts(value)
-    @@narrowFont = MessageConfig.pbDefaultNarrowFontName if @@narrowFont == ""
+    @@narrowFont = MessageConfig.pbDefaultNarrowFontName if @@narrowFont.empty?
   end
 
   def self.pbTryFonts(*args)
@@ -152,7 +152,7 @@ module MessageConfig
       when Array
         a.each do |aa|
           ret = MessageConfig.pbTryFonts(aa)
-          return ret if ret != ""
+          return ret if !ret.empty?
         end
       end
     end

--- a/Data/Scripts/007_Objects and windows/002_MessageConfig.rb
+++ b/Data/Scripts/007_Objects and windows/002_MessageConfig.rb
@@ -41,7 +41,7 @@ module MessageConfig
 
   def self.pbDefaultWindowskin
     skin = ($data_system) ? $data_system.windowskin_name : nil
-    if skin && skin != ""
+    if !nil_or_empty?(skin)
       skin = pbResolveBitmap("Graphics/Windowskins/" + skin) || ""
     end
     skin = pbResolveBitmap("Graphics/System/Window") if nil_or_empty?(skin)

--- a/Data/Scripts/007_Objects and windows/002_MessageConfig.rb
+++ b/Data/Scripts/007_Objects and windows/002_MessageConfig.rb
@@ -41,9 +41,7 @@ module MessageConfig
 
   def self.pbDefaultWindowskin
     skin = ($data_system) ? $data_system.windowskin_name : nil
-    if !nil_or_empty?(skin)
-      skin = pbResolveBitmap("Graphics/Windowskins/" + skin) || ""
-    end
+    skin = pbResolveBitmap("Graphics/Windowskins/" + skin) || "" unless nil_or_empty?(skin)
     skin = pbResolveBitmap("Graphics/System/Window") if nil_or_empty?(skin)
     skin = pbResolveBitmap("Graphics/Windowskins/001-Blue01") if nil_or_empty?(skin)
     return skin || ""

--- a/Data/Scripts/007_Objects and windows/004_SpriteWindow.rb
+++ b/Data/Scripts/007_Objects and windows/004_SpriteWindow.rb
@@ -854,7 +854,7 @@ class SpriteWindow_Base < SpriteWindow
         @resolvedFrame = MessageConfig.pbGetSystemFrame
         @resolvedFrame.sub!(/\.[^\.\/\\]+$/, "")
       end
-      self.loadSkinFile("#{@resolvedFrame}.txt") if @resolvedFrame != ""
+      self.loadSkinFile("#{@resolvedFrame}.txt") if !@resolvedFrame.empty?
     end
   end
 

--- a/Data/Scripts/007_Objects and windows/006_SpriteWindow_pictures.rb
+++ b/Data/Scripts/007_Objects and windows/006_SpriteWindow_pictures.rb
@@ -41,7 +41,7 @@ class IconWindow < SpriteWindow_Base
     clearBitmaps
     @name = file
     return if file.nil?
-    if file == ""
+    if file.empty?
       @_iconbitmap = nil
     else
       @_iconbitmap = AnimatedBitmap.new(file, hue)

--- a/Data/Scripts/007_Objects and windows/006_SpriteWindow_pictures.rb
+++ b/Data/Scripts/007_Objects and windows/006_SpriteWindow_pictures.rb
@@ -93,19 +93,19 @@ class PictureWindow < SpriteWindow_Base
   # is ignored unless pathOrBitmap is a filename)
   def setBitmap(pathOrBitmap, hue = 0)
     clearBitmaps
-    if pathOrBitmap != nil && pathOrBitmap != ""
-      case pathOrBitmap
-      when Bitmap
-        @_iconbitmap = pathOrBitmap
-        self.contents = @_iconbitmap
-        self.width = @_iconbitmap.width + self.borderX
-        self.height = @_iconbitmap.height + self.borderY
-      when AnimatedBitmap
-        @_iconbitmap = pathOrBitmap
-        self.contents = @_iconbitmap.bitmap
-        self.width = @_iconbitmap.bitmap.width + self.borderX
-        self.height = @_iconbitmap.bitmap.height + self.borderY
-      else
+    case pathOrBitmap
+    when Bitmap
+      @_iconbitmap = pathOrBitmap
+      self.contents = @_iconbitmap
+      self.width = @_iconbitmap.width + self.borderX
+      self.height = @_iconbitmap.height + self.borderY
+    when AnimatedBitmap
+      @_iconbitmap = pathOrBitmap
+      self.contents = @_iconbitmap.bitmap
+      self.width = @_iconbitmap.bitmap.width + self.borderX
+      self.height = @_iconbitmap.bitmap.height + self.borderY
+    when String
+      if !nil_or_empty?(pathOrBitmap)
         @_iconbitmap = AnimatedBitmap.new(pathOrBitmap, hue)
         self.contents = @_iconbitmap&.bitmap
         self.width = self.borderX + (@_iconbitmap&.bitmap&.width || 32)

--- a/Data/Scripts/007_Objects and windows/007_SpriteWrapper.rb
+++ b/Data/Scripts/007_Objects and windows/007_SpriteWrapper.rb
@@ -281,7 +281,7 @@ class IconSprite < SpriteWrapper
     clearBitmaps
     @name = file
     return if file.nil?
-    if file == ""
+    if file.empty?
       @_iconbitmap = nil
     else
       @_iconbitmap = AnimatedBitmap.new(file, hue)

--- a/Data/Scripts/007_Objects and windows/010_DrawText.rb
+++ b/Data/Scripts/007_Objects and windows/010_DrawText.rb
@@ -499,8 +499,8 @@ def getFormattedText(bitmap, xDst, yDst, widthDst, heightDst, text, lineheight =
             param = param.split(",")
             # get pure colors unaffected by opacity
             oldColors = getLastParam(colorstack, defaultcolors)
-            base = (!nil_or_empty?(param[0])) ? rgbToColor(param[0]) : oldColors[0]
-            shadow = (!nil_or_empty?(param[1])) ? rgbToColor(param[1]) : oldColors[1]
+            base   = (nil_or_empty?(param[0]) ? oldColors[0] : rgbToColor(param[0]))
+            shadow = (nil_or_empty?(param[1]) ? oldColors[1] : rgbToColor(param[1]))
             colorstack.push([base, shadow])
           end
         when "o"
@@ -939,9 +939,7 @@ def getLineBrokenChunks(bitmap, value, width, dims, plain = false)
         x += textwidth
         dims[0] = x if dims && dims[0] < x
       end
-      if textcols[i]
-        color = textcols[i]
-      end
+      color = textcols[i] if textcols[i]
     end
   end
   dims[1] = y + 32 if dims

--- a/Data/Scripts/007_Objects and windows/010_DrawText.rb
+++ b/Data/Scripts/007_Objects and windows/010_DrawText.rb
@@ -499,8 +499,8 @@ def getFormattedText(bitmap, xDst, yDst, widthDst, heightDst, text, lineheight =
             param = param.split(",")
             # get pure colors unaffected by opacity
             oldColors = getLastParam(colorstack, defaultcolors)
-            base = (param[0] && param[0] != "") ? rgbToColor(param[0]) : oldColors[0]
-            shadow = (param[1] && param[1] != "") ? rgbToColor(param[1]) : oldColors[1]
+            base = (!nil_or_empty?(param[0])) ? rgbToColor(param[0]) : oldColors[0]
+            shadow = (!nil_or_empty?(param[1])) ? rgbToColor(param[1]) : oldColors[1]
             colorstack.push([base, shadow])
           end
         when "o"
@@ -854,8 +854,7 @@ def getLineBrokenText(bitmap, value, width, dims)
   return ret if !bitmap || bitmap.disposed? || width <= 0
   textmsg = value.clone
   ret.push(["", 0, 0, 0, bitmap.text_size("X").height, 0, 0, 0, 0])
-  while (c = textmsg.slice!(/\n|(\S*([ \r\t\f]?))/)) != nil
-    break if c == ""
+  while !nil_or_empty?(c = textmsg.slice!(/\n|(\S*([ \r\t\f]?))/))
     length = c.scan(/./m).length
     ccheck = c
     if ccheck == "\n"
@@ -872,7 +871,7 @@ def getLineBrokenText(bitmap, value, width, dims)
     words = [ccheck]
     words.length.times do |i|
       word = words[i]
-      if word && word != ""
+      if !nil_or_empty?(word)
         textSize = bitmap.text_size(word)
         textwidth = textSize.width
         if x > 0 && x + textwidth >= width - 2
@@ -910,8 +909,7 @@ def getLineBrokenChunks(bitmap, value, width, dims, plain = false)
   return ret if !bitmap || bitmap.disposed? || width <= 0
   textmsg = value.clone
   color = Font.default_color
-  while (c = textmsg.slice!(/\n|[^ \r\t\f\n\-]*\-+|(\S*([ \r\t\f]?))/)) != nil
-    break if c == ""
+  while !nil_or_empty?(c = textmsg.slice!(/\n|[^ \r\t\f\n\-]*\-+|(\S*([ \r\t\f]?))/))
     ccheck = c
     if ccheck == "\n"
       x = 0
@@ -927,7 +925,7 @@ def getLineBrokenChunks(bitmap, value, width, dims, plain = false)
     end
     words.length.times do |i|
       word = words[i]
-      if word && word != ""
+      if !nil_or_empty?(word)
         textSize = bitmap.text_size(word)
         textwidth = textSize.width
         if x > 0 && x + textwidth > width

--- a/Data/Scripts/007_Objects and windows/011_Messages.rb
+++ b/Data/Scripts/007_Objects and windows/011_Messages.rb
@@ -557,7 +557,7 @@ def pbMessageDisplay(msgwindow, message, letterbyletter = true, commandProc = ni
       end
     end
   end
-  if startSE != nil
+  if !startSE.nil?
     pbSEPlay(pbStringToAudioFile(startSE))
   elsif signWaitCount == 0 && letterbyletter
     pbPlayDecisionSE

--- a/Data/Scripts/007_Objects and windows/011_Messages.rb
+++ b/Data/Scripts/007_Objects and windows/011_Messages.rb
@@ -458,7 +458,7 @@ def pbMessageDisplay(msgwindow, message, letterbyletter = true, commandProc = ni
   text.gsub!(/\\r/i,   "<c3=E00808,D0D0C8>")
   text.gsub!(/\\[Ww]\[([^\]]*)\]/) {
     w = $1.to_s
-    if w == ""
+    if w.empty?
       msgwindow.windowskin = nil
     else
       msgwindow.setSkin("Graphics/Windowskins/#{w}", false)
@@ -627,7 +627,7 @@ def pbMessageDisplay(msgwindow, message, letterbyletter = true, commandProc = ni
         pbPositionNearMsgWindow(facewindow, msgwindow, :left)
         msgwindow.y = Graphics.height - (msgwindow.height * (signWaitTime - signWaitCount) / signWaitTime)
       when "ts"     # Change text speed
-        msgwindow.textspeed = (param == "") ? -999 : param.to_i
+        msgwindow.textspeed = (param.empty?) ? -999 : param.to_i
       when "."      # Wait 0.25 seconds
         msgwindow.waitcount += Graphics.frame_rate / 4
       when "|"      # Wait 1 second

--- a/Data/Scripts/007_Objects and windows/012_TextEntry.rb
+++ b/Data/Scripts/007_Objects and windows/012_TextEntry.rb
@@ -16,9 +16,7 @@ class CharacterEntryHelper
 
   def textChars
     chars = text.scan(/./m)
-    if @passwordChar != ""
-      chars.length.times { |i| chars[i] = @passwordChar }
-    end
+    chars.length.times { |i| chars[i] = @passwordChar } if !@passwordChar.empty?
     return chars
   end
 
@@ -193,13 +191,13 @@ class Window_TextEntry < SpriteWindow_Base
     startpos = @helper.cursor
     fromcursor = 0
     while startpos > 0
-      c = (@helper.passwordChar != "") ? @helper.passwordChar : textscan[startpos - 1]
+      c = (!@helper.passwordChar.empty?) ? @helper.passwordChar : textscan[startpos - 1]
       fromcursor += bitmap.text_size(c).width
       break if fromcursor > width - 4
       startpos -= 1
     end
     (startpos...scanlength).each do |i|
-      c = (@helper.passwordChar != "") ? @helper.passwordChar : textscan[i]
+      c = (!@helper.passwordChar.empty?) ? @helper.passwordChar : textscan[i]
       textwidth = bitmap.text_size(c).width
       next if c == "\n"
       # Draw text

--- a/Data/Scripts/008_Audio/002_Audio_Play.rb
+++ b/Data/Scripts/008_Audio/002_Audio_Play.rb
@@ -52,7 +52,7 @@ end
 def pbBGMPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if param.name && param.name != ""
+  if !nil_or_empty?(param&.name)
     if $game_system
       $game_system.bgm_play(param)
       return
@@ -102,7 +102,7 @@ end
 def pbMEPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if param.name && param.name != ""
+  if !nil_or_empty?(param&.name)
     if $game_system
       $game_system.me_play(param)
       return
@@ -152,7 +152,7 @@ end
 def pbBGSPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if param.name && param.name != ""
+  if !nil_or_empty?(param&.name)
     if $game_system
       $game_system.bgs_play(param)
       return
@@ -202,7 +202,7 @@ end
 def pbSEPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if param.name && param.name != ""
+  if !nil_or_empty?(param&.name)
     if $game_system
       $game_system.se_play(param)
       return

--- a/Data/Scripts/008_Audio/002_Audio_Play.rb
+++ b/Data/Scripts/008_Audio/002_Audio_Play.rb
@@ -52,19 +52,18 @@ end
 def pbBGMPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if !nil_or_empty?(param&.name)
-    if $game_system
-      $game_system.bgm_play(param)
+  return if nil_or_empty?(param&.name)
+  if $game_system
+    $game_system.bgm_play(param)
+    return
+  elsif (RPG.const_defined?(:BGM) rescue false)
+    b = RPG::BGM.new(param.name, param.volume, param.pitch)
+    if b.respond_to?("play")
+      b.play
       return
-    elsif (RPG.const_defined?(:BGM) rescue false)
-      b = RPG::BGM.new(param.name, param.volume, param.pitch)
-      if b.respond_to?("play")
-        b.play
-        return
-      end
     end
-    Audio.bgm_play(canonicalize("Audio/BGM/" + param.name), param.volume, param.pitch)
   end
+  Audio.bgm_play(canonicalize("Audio/BGM/" + param.name), param.volume, param.pitch)
 end
 
 # Fades out or stops BGM playback. 'x' is the time in seconds to fade out.
@@ -102,19 +101,18 @@ end
 def pbMEPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if !nil_or_empty?(param&.name)
-    if $game_system
-      $game_system.me_play(param)
+  return if nil_or_empty?(param&.name)
+  if $game_system
+    $game_system.me_play(param)
+    return
+  elsif (RPG.const_defined?(:ME) rescue false)
+    b = RPG::ME.new(param.name, param.volume, param.pitch)
+    if b.respond_to?("play")
+      b.play
       return
-    elsif (RPG.const_defined?(:ME) rescue false)
-      b = RPG::ME.new(param.name, param.volume, param.pitch)
-      if b.respond_to?("play")
-        b.play
-        return
-      end
     end
-    Audio.me_play(canonicalize("Audio/ME/" + param.name), param.volume, param.pitch)
   end
+  Audio.me_play(canonicalize("Audio/ME/" + param.name), param.volume, param.pitch)
 end
 
 # Fades out or stops ME playback. 'x' is the time in seconds to fade out.
@@ -152,19 +150,18 @@ end
 def pbBGSPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if !nil_or_empty?(param&.name)
-    if $game_system
-      $game_system.bgs_play(param)
+  return if nil_or_empty?(param&.name)
+  if $game_system
+    $game_system.bgs_play(param)
+    return
+  elsif (RPG.const_defined?(:BGS) rescue false)
+    b = RPG::BGS.new(param.name, param.volume, param.pitch)
+    if b.respond_to?("play")
+      b.play
       return
-    elsif (RPG.const_defined?(:BGS) rescue false)
-      b = RPG::BGS.new(param.name, param.volume, param.pitch)
-      if b.respond_to?("play")
-        b.play
-        return
-      end
     end
-    Audio.bgs_play(canonicalize("Audio/BGS/" + param.name), param.volume, param.pitch)
   end
+  Audio.bgs_play(canonicalize("Audio/BGS/" + param.name), param.volume, param.pitch)
 end
 
 # Fades out or stops BGS playback. 'x' is the time in seconds to fade out.
@@ -202,20 +199,19 @@ end
 def pbSEPlay(param, volume = nil, pitch = nil)
   return if !param
   param = pbResolveAudioFile(param, volume, pitch)
-  if !nil_or_empty?(param&.name)
-    if $game_system
-      $game_system.se_play(param)
+  return if nil_or_empty?(param&.name)
+  if $game_system
+    $game_system.se_play(param)
+    return
+  end
+  if (RPG.const_defined?(:SE) rescue false)
+    b = RPG::SE.new(param.name, param.volume, param.pitch)
+    if b.respond_to?("play")
+      b.play
       return
     end
-    if (RPG.const_defined?(:SE) rescue false)
-      b = RPG::SE.new(param.name, param.volume, param.pitch)
-      if b.respond_to?("play")
-        b.play
-        return
-      end
-    end
-    Audio.se_play(canonicalize("Audio/SE/" + param.name), param.volume, param.pitch)
   end
+  Audio.se_play(canonicalize("Audio/SE/" + param.name), param.volume, param.pitch)
 end
 
 # Stops SE playback.

--- a/Data/Scripts/009_Scenes/001_Transitions.rb
+++ b/Data/Scripts/009_Scenes/001_Transitions.rb
@@ -26,7 +26,7 @@ module Graphics
     begin
       transition_KGC_SpecialTransition(duration, filename, vague)
     rescue Exception
-      transition_KGC_SpecialTransition(duration, "", vague) if filename != ""
+      transition_KGC_SpecialTransition(duration, "", vague) if !filename.empty?
     end
     if STOP_WHILE_TRANSITION && !@_interrupt_transition
       while @@transition && !@@transition.disposed?

--- a/Data/Scripts/009_Scenes/002_EventScene.rb
+++ b/Data/Scripts/009_Scenes/002_EventScene.rb
@@ -24,14 +24,14 @@ class PictureSprite < SpriteWrapper
     super
     @pictureBitmap&.update
     # If picture file name is different from current one
-    if @customBitmap && @picture.name == ""
+    if @customBitmap && @picture.name.empty?
       self.bitmap = (@customBitmapIsBitmap) ? @customBitmap : @customBitmap.bitmap
     elsif @picture_name != @picture.name || @picture.hue.to_i != @hue.to_i
       # Remember file name to instance variables
       @picture_name = @picture.name
       @hue = @picture.hue.to_i
       # If file name is not empty
-      if @picture_name == ""
+      if @picture_name.empty?
         @pictureBitmap&.dispose
         @pictureBitmap = nil
         self.visible = false
@@ -41,7 +41,7 @@ class PictureSprite < SpriteWrapper
       @pictureBitmap&.dispose
       @pictureBitmap = AnimatedBitmap.new(@picture_name, @hue)
       self.bitmap = (@pictureBitmap) ? @pictureBitmap.bitmap : nil
-    elsif @picture_name == ""
+    elsif @picture_name.empty?
       # Set sprite to invisible
       self.visible = false
       return

--- a/Data/Scripts/011_Battle/001_Battle/001_Battle.rb
+++ b/Data/Scripts/011_Battle/001_Battle/001_Battle.rb
@@ -115,8 +115,8 @@ class Battle
     @turnCount         = 0
     @decision          = 0
     @caughtPokemon     = []
-    player   = [player] if !player.nil? && !player.is_a?(Array)
-    opponent = [opponent] if !opponent.nil? && !opponent.is_a?(Array)
+    player   = [player]   unless player.nil?   || player.is_a?(Array)
+    opponent = [opponent] unless opponent.nil? || opponent.is_a?(Array)
     @player            = player     # Array of Player/NPCTrainer objects, or nil
     @opponent          = opponent   # Array of NPCTrainer objects, or nil
     @items             = nil

--- a/Data/Scripts/011_Battle/001_Battle/002_Battle_StartAndEnd.rb
+++ b/Data/Scripts/011_Battle/001_Battle/002_Battle_StartAndEnd.rb
@@ -413,7 +413,7 @@ class Battle
         end
         @opponent.each_with_index do |_t, i|
           @scene.pbShowOpponent(i)
-          msg = (@endSpeeches[i] && @endSpeeches[i] != "") ? @endSpeeches[i] : "..."
+          msg = (!nil_or_empty?(@endSpeeches[i])) ? @endSpeeches[i] : "..."
           pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name))
         end
       end
@@ -447,7 +447,7 @@ class Battle
         if @opponent
           @opponent.each_with_index do |_t, i|
             @scene.pbShowOpponent(i)
-            msg = (@endSpeechesWin[i] && @endSpeechesWin[i] != "") ? @endSpeechesWin[i] : "..."
+            msg = (!nil_or_empty?(@endSpeechesWin[i])) ? @endSpeechesWin[i] : "..."
             pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name))
           end
         end

--- a/Data/Scripts/011_Battle/001_Battle/002_Battle_StartAndEnd.rb
+++ b/Data/Scripts/011_Battle/001_Battle/002_Battle_StartAndEnd.rb
@@ -106,9 +106,7 @@ class Battle
   # Set up all battlers
   #=============================================================================
   def pbCreateBattler(idxBattler, pkmn, idxParty)
-    if !@battlers[idxBattler].nil?
-      raise _INTL("Battler index {1} already exists", idxBattler)
-    end
+    raise _INTL("Battler index {1} already exists", idxBattler) if !@battlers[idxBattler].nil?
     @battlers[idxBattler] = Battler.new(self, idxBattler)
     @positions[idxBattler] = ActivePosition.new
     pbClearChoice(idxBattler)
@@ -413,7 +411,7 @@ class Battle
         end
         @opponent.each_with_index do |_t, i|
           @scene.pbShowOpponent(i)
-          msg = (!nil_or_empty?(@endSpeeches[i])) ? @endSpeeches[i] : "..."
+          msg = (nil_or_empty?(@endSpeeches[i]) ? "..." : @endSpeeches[i])
           pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name))
         end
       end
@@ -447,7 +445,7 @@ class Battle
         if @opponent
           @opponent.each_with_index do |_t, i|
             @scene.pbShowOpponent(i)
-            msg = (!nil_or_empty?(@endSpeechesWin[i])) ? @endSpeechesWin[i] : "..."
+            msg = (nil_or_empty?(@endSpeechesWin[i]) ? "..." : @endSpeechesWin[i])
             pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name))
           end
         end

--- a/Data/Scripts/011_Battle/002_Battler/003_Battler_ChangeSelf.rb
+++ b/Data/Scripts/011_Battle/002_Battler/003_Battler_ChangeSelf.rb
@@ -160,7 +160,7 @@ class Battle::Battler
     @effects[PBEffects::WeightChange] = 0 if Settings::MECHANICS_GENERATION >= 6
     @battle.scene.pbChangePokemon(self, @pokemon)
     @battle.scene.pbRefreshOne(@index)
-    @battle.pbDisplay(msg) if msg && msg != ""
+    @battle.pbDisplay(msg) if !nil_or_empty?(msg)
     PBDebug.log("[Form changed] #{pbThis} changed from form #{oldForm} to form #{newForm}")
     @battle.pbSetSeen(self)
   end

--- a/Data/Scripts/011_Battle/003_Move/007_MoveEffects_BattlerOther.rb
+++ b/Data/Scripts/011_Battle/003_Move/007_MoveEffects_BattlerOther.rb
@@ -377,7 +377,7 @@ class Battle::Move::GiveUserStatusToTarget < Battle::Move
       target.pbFreeze
       msg = _INTL("{1} was thawed out.", user.pbThis)
     end
-    if msg != ""
+    if !nil_or_empty?(msg)
       user.pbCureStatus(false)
       @battle.pbDisplay(msg)
     end

--- a/Data/Scripts/011_Battle/003_Move/010_MoveEffects_Healing.rb
+++ b/Data/Scripts/011_Battle/003_Move/010_MoveEffects_Healing.rb
@@ -462,7 +462,7 @@ class Battle::Move::UserLosesHalfOfTotalHPExplosive < Battle::Move
   def pbMoveFailed?(user, targets)
     if !@battle.moldBreaker
       bearer = @battle.pbCheckGlobalAbility(:DAMP)
-      if bearer != nil
+      if !bearer.nil?
         @battle.pbShowAbilitySplash(bearer)
         if Battle::Scene::USE_ABILITY_SPLASH
           @battle.pbDisplay(_INTL("{1} cannot use {2}!", user.pbThis, @name))
@@ -494,7 +494,7 @@ class Battle::Move::UserFaintsExplosive < Battle::Move
   def pbMoveFailed?(user, targets)
     if !@battle.moldBreaker
       bearer = @battle.pbCheckGlobalAbility(:DAMP)
-      if bearer != nil
+      if !bearer.nil?
         @battle.pbShowAbilitySplash(bearer)
         if Battle::Scene::USE_ABILITY_SPLASH
           @battle.pbDisplay(_INTL("{1} cannot use {2}!", user.pbThis, @name))

--- a/Data/Scripts/011_Battle/003_Move/010_MoveEffects_Healing.rb
+++ b/Data/Scripts/011_Battle/003_Move/010_MoveEffects_Healing.rb
@@ -462,7 +462,7 @@ class Battle::Move::UserLosesHalfOfTotalHPExplosive < Battle::Move
   def pbMoveFailed?(user, targets)
     if !@battle.moldBreaker
       bearer = @battle.pbCheckGlobalAbility(:DAMP)
-      if !bearer.nil?
+      if bearer
         @battle.pbShowAbilitySplash(bearer)
         if Battle::Scene::USE_ABILITY_SPLASH
           @battle.pbDisplay(_INTL("{1} cannot use {2}!", user.pbThis, @name))
@@ -494,7 +494,7 @@ class Battle::Move::UserFaintsExplosive < Battle::Move
   def pbMoveFailed?(user, targets)
     if !@battle.moldBreaker
       bearer = @battle.pbCheckGlobalAbility(:DAMP)
-      if !bearer.nil?
+      if bearer
         @battle.pbShowAbilitySplash(bearer)
         if Battle::Scene::USE_ABILITY_SPLASH
           @battle.pbDisplay(_INTL("{1} cannot use {2}!", user.pbThis, @name))

--- a/Data/Scripts/011_Battle/004_Scene/003_Scene_ChooseCommands.rb
+++ b/Data/Scripts/011_Battle/004_Scene/003_Scene_ChooseCommands.rb
@@ -195,8 +195,8 @@ class Battle::Scene
     # Set Bag starting positions
     oldLastPocket = $bag.last_viewed_pocket
     oldChoices    = $bag.last_pocket_selections.clone
-    $bag.last_viewed_pocket     = @bagLastPocket if !@bagLastPocket.nil?
-    $bag.last_pocket_selections = @bagChoices if !@bagChoices.nil?
+    $bag.last_viewed_pocket     = @bagLastPocket unless @bagLastPocket.nil?
+    $bag.last_pocket_selections = @bagChoices unless @bagChoices.nil?
     # Start Bag screen
     itemScene = PokemonBag_Scene.new
     itemScene.pbStartScene($bag, true,

--- a/Data/Scripts/011_Battle/004_Scene/003_Scene_ChooseCommands.rb
+++ b/Data/Scripts/011_Battle/004_Scene/003_Scene_ChooseCommands.rb
@@ -195,8 +195,8 @@ class Battle::Scene
     # Set Bag starting positions
     oldLastPocket = $bag.last_viewed_pocket
     oldChoices    = $bag.last_pocket_selections.clone
-    $bag.last_viewed_pocket     = @bagLastPocket if @bagLastPocket != nil
-    $bag.last_pocket_selections = @bagChoices if @bagChoices != nil
+    $bag.last_viewed_pocket     = @bagLastPocket if !@bagLastPocket.nil?
+    $bag.last_pocket_selections = @bagChoices if !@bagChoices.nil?
     # Start Bag screen
     itemScene = PokemonBag_Scene.new
     itemScene.pbStartScene($bag, true,

--- a/Data/Scripts/011_Battle/004_Scene/004_Scene_PlayAnimations.rb
+++ b/Data/Scripts/011_Battle/004_Scene/004_Scene_PlayAnimations.rb
@@ -515,7 +515,7 @@ class Battle::Scene
     return if !animations
     animations.each do |a|
       next if !a || a.name != "Common:" + animName
-      pbAnimationCore(a, user, (target != nil) ? target : user)
+      pbAnimationCore(a, user, (!target.nil? ? target : user))
       return
     end
   end

--- a/Data/Scripts/011_Battle/004_Scene/004_Scene_PlayAnimations.rb
+++ b/Data/Scripts/011_Battle/004_Scene/004_Scene_PlayAnimations.rb
@@ -515,7 +515,7 @@ class Battle::Scene
     return if !animations
     animations.each do |a|
       next if !a || a.name != "Common:" + animName
-      pbAnimationCore(a, user, (!target.nil? ? target : user))
+      pbAnimationCore(a, user, target || user)
       return
     end
   end

--- a/Data/Scripts/011_Battle/004_Scene/005_Battle_Scene_Menus.rb
+++ b/Data/Scripts/011_Battle/004_Scene/005_Battle_Scene_Menus.rb
@@ -174,9 +174,7 @@ class Battle::Scene::CommandMenu < Battle::Scene::MenuBase
     @msgBox.text = value[0]
     return if USE_GRAPHICS
     commands = []
-    (1..4).each do |i|
-      commands.push(value[i]) if value[i] && value[i] != nil
-    end
+    (1..4).each { |i| commands.push(value[i]) if !nil_or_empty?(value[i]) }
     @cmdWindow.commands = commands
   end
 

--- a/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
@@ -287,57 +287,57 @@ class PBAnimTiming
     when 1
       text = sprintf("[%d] Set BG: \"%s\"", @frame + 1, name)
       text += sprintf(" (color=%s,%s,%s,%s)",
-                      (@colorRed != nil)   ? @colorRed.to_i   : "-",
-                      (@colorGreen != nil) ? @colorGreen.to_i : "-",
-                      (@colorBlue != nil)  ? @colorBlue.to_i  : "-",
-                      (@colorAlpha != nil) ? @colorAlpha.to_i : "-")
+                      (!@colorRed.nil?)   ? @colorRed.to_i   : "-",
+                      (!@colorGreen.nil?) ? @colorGreen.to_i : "-",
+                      (!@colorBlue.nil?)  ? @colorBlue.to_i  : "-",
+                      (!@colorAlpha.nil?) ? @colorAlpha.to_i : "-")
       text += sprintf(" (opacity=%s)", @opacity.to_i)
       text += sprintf(" (coords=%s,%s)",
-                      (@bgX != nil) ? @bgX : "-",
-                      (@bgY != nil) ? @bgY : "-")
+                      (!@bgX.nil?) ? @bgX : "-",
+                      (!@bgY.nil?) ? @bgY : "-")
       return text
     when 2
       text = sprintf("[%d] Change BG: @%d", @frame + 1, duration)
-      if @colorRed != nil || @colorGreen != nil || @colorBlue != nil || @colorAlpha != nil
+      if !@colorRed.nil? || !@colorGreen.nil? || !@colorBlue.nil? || !@colorAlpha.nil?
         text += sprintf(" (color=%s,%s,%s,%s)",
-                        (@colorRed != nil)   ? @colorRed.to_i   : "-",
-                        (@colorGreen != nil) ? @colorGreen.to_i : "-",
-                        (@colorBlue != nil)  ? @colorBlue.to_i  : "-",
-                        (@colorAlpha != nil) ? @colorAlpha.to_i : "-")
+                        (!@colorRed.nil?)   ? @colorRed.to_i   : "-",
+                        (!@colorGreen.nil?) ? @colorGreen.to_i : "-",
+                        (!@colorBlue.nil?)  ? @colorBlue.to_i  : "-",
+                        (!@colorAlpha.nil?) ? @colorAlpha.to_i : "-")
       end
-      text += sprintf(" (opacity=%s)", @opacity.to_i) if @opacity != nil
-      if @bgX != nil || @bgY != nil
+      text += sprintf(" (opacity=%s)", @opacity.to_i) if !@opacity.nil?
+      if !@bgX.nil? || !@bgY.nil?
         text += sprintf(" (coords=%s,%s)",
-                        (@bgX != nil) ? @bgX : "-",
-                        (@bgY != nil) ? @bgY : "-")
+                        (!@bgX.nil?) ? @bgX : "-",
+                        (!@bgY.nil?) ? @bgY : "-")
       end
       return text
     when 3
       text = sprintf("[%d] Set FG: \"%s\"", @frame + 1, name)
       text += sprintf(" (color=%s,%s,%s,%s)",
-                      (@colorRed != nil)   ? @colorRed.to_i   : "-",
-                      (@colorGreen != nil) ? @colorGreen.to_i : "-",
-                      (@colorBlue != nil)  ? @colorBlue.to_i  : "-",
-                      (@colorAlpha != nil) ? @colorAlpha.to_i : "-")
+                      (!@colorRed.nil?)   ? @colorRed.to_i   : "-",
+                      (!@colorGreen.nil?) ? @colorGreen.to_i : "-",
+                      (!@colorBlue.nil?)  ? @colorBlue.to_i  : "-",
+                      (!@colorAlpha.nil?) ? @colorAlpha.to_i : "-")
       text += sprintf(" (opacity=%s)", @opacity.to_i)
       text += sprintf(" (coords=%s,%s)",
-                      (@bgX != nil) ? @bgX : "-",
-                      (@bgY != nil) ? @bgY : "-")
+                      (!@bgX.nil?) ? @bgX : "-",
+                      (!@bgY.nil?) ? @bgY : "-")
       return text
     when 4
       text = sprintf("[%d] Change FG: @%d", @frame + 1, duration)
-      if @colorRed != nil || @colorGreen != nil || @colorBlue != nil || @colorAlpha != nil
+      if !@colorRed.nil? || !@colorGreen.nil? || !@colorBlue.nil? || !@colorAlpha.nil?
         text += sprintf(" (color=%s,%s,%s,%s)",
-                        (@colorRed != nil)   ? @colorRed.to_i   : "-",
-                        (@colorGreen != nil) ? @colorGreen.to_i : "-",
-                        (@colorBlue != nil)  ? @colorBlue.to_i  : "-",
-                        (@colorAlpha != nil) ? @colorAlpha.to_i : "-")
+                        (!@colorRed.nil?)   ? @colorRed.to_i   : "-",
+                        (!@colorGreen.nil?) ? @colorGreen.to_i : "-",
+                        (!@colorBlue.nil?)  ? @colorBlue.to_i  : "-",
+                        (!@colorAlpha.nil?) ? @colorAlpha.to_i : "-")
       end
-      text += sprintf(" (opacity=%s)", @opacity.to_i) if @opacity != nil
-      if @bgX != nil || @bgY != nil
+      text += sprintf(" (opacity=%s)", @opacity.to_i) if !@opacity.nil?
+      if !@bgX.nil? || !@bgY.nil?
         text += sprintf(" (coords=%s,%s)",
-                        (@bgX != nil) ? @bgX : "-",
-                        (@bgY != nil) ? @bgY : "-")
+                        (!@bgX.nil?) ? @bgX : "-",
+                        (!@bgY.nil?) ? @bgY : "-")
       end
       return text
     end
@@ -563,20 +563,20 @@ class PBAnimation < Array
         next if frame < i.frame || frame > i.frame + i.duration
         fraction = (frame - i.frame).to_f / i.duration
         if bgGraphic.bitmap.nil?
-          bgColor.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) if i.opacity != nil
-          cr = (i.colorRed != nil) ? oldbg[3].red + ((i.colorRed - oldbg[3].red) * fraction) : oldbg[3].red
-          cg = (i.colorGreen != nil) ? oldbg[3].green + ((i.colorGreen - oldbg[3].green) * fraction) : oldbg[3].green
-          cb = (i.colorBlue != nil) ? oldbg[3].blue + ((i.colorBlue - oldbg[3].blue) * fraction) : oldbg[3].blue
-          ca = (i.colorAlpha != nil) ? oldbg[3].alpha + ((i.colorAlpha - oldbg[3].alpha) * fraction) : oldbg[3].alpha
+          bgColor.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) if !i.opacity.nil?
+          cr = (!i.colorRed.nil?)   ? oldbg[3].red   + ((i.colorRed   - oldbg[3].red)   * fraction) : oldbg[3].red
+          cg = (!i.colorGreen.nil?) ? oldbg[3].green + ((i.colorGreen - oldbg[3].green) * fraction) : oldbg[3].green
+          cb = (!i.colorBlue.nil?)  ? oldbg[3].blue  + ((i.colorBlue  - oldbg[3].blue)  * fraction) : oldbg[3].blue
+          ca = (!i.colorAlpha.nil?) ? oldbg[3].alpha + ((i.colorAlpha - oldbg[3].alpha) * fraction) : oldbg[3].alpha
           bgColor.color = Color.new(cr, cg, cb, ca)
         else
-          bgGraphic.ox      = oldbg[0] - ((i.bgX - oldbg[0]) * fraction) if i.bgX != nil
-          bgGraphic.oy      = oldbg[1] - ((i.bgY - oldbg[1]) * fraction) if i.bgY != nil
-          bgGraphic.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) if i.opacity != nil
-          cr = (i.colorRed != nil) ? oldbg[3].red + ((i.colorRed - oldbg[3].red) * fraction) : oldbg[3].red
-          cg = (i.colorGreen != nil) ? oldbg[3].green + ((i.colorGreen - oldbg[3].green) * fraction) : oldbg[3].green
-          cb = (i.colorBlue != nil) ? oldbg[3].blue + ((i.colorBlue - oldbg[3].blue) * fraction) : oldbg[3].blue
-          ca = (i.colorAlpha != nil) ? oldbg[3].alpha + ((i.colorAlpha - oldbg[3].alpha) * fraction) : oldbg[3].alpha
+          bgGraphic.ox      = oldbg[0] - ((i.bgX     - oldbg[0]) * fraction) if !i.bgX.nil?
+          bgGraphic.oy      = oldbg[1] - ((i.bgY     - oldbg[1]) * fraction) if !i.bgY.nil?
+          bgGraphic.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) if !i.opacity.nil?
+          cr = (!i.colorRed.nil?)   ? oldbg[3].red   + ((i.colorRed   - oldbg[3].red)   * fraction) : oldbg[3].red
+          cg = (!i.colorGreen.nil?) ? oldbg[3].green + ((i.colorGreen - oldbg[3].green) * fraction) : oldbg[3].green
+          cb = (!i.colorBlue.nil?)  ? oldbg[3].blue  + ((i.colorBlue  - oldbg[3].blue)  * fraction) : oldbg[3].blue
+          ca = (!i.colorAlpha.nil?) ? oldbg[3].alpha + ((i.colorAlpha - oldbg[3].alpha) * fraction) : oldbg[3].alpha
           bgGraphic.color = Color.new(cr, cg, cb, ca)
         end
       when 4
@@ -584,20 +584,20 @@ class PBAnimation < Array
         next if frame < i.frame || frame > i.frame + i.duration
         fraction = (frame - i.frame).to_f / i.duration
         if foGraphic.bitmap.nil?
-          foColor.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) if i.opacity != nil
-          cr = (i.colorRed != nil) ? oldfo[3].red + ((i.colorRed - oldfo[3].red) * fraction) : oldfo[3].red
-          cg = (i.colorGreen != nil) ? oldfo[3].green + ((i.colorGreen - oldfo[3].green) * fraction) : oldfo[3].green
-          cb = (i.colorBlue != nil) ? oldfo[3].blue + ((i.colorBlue - oldfo[3].blue) * fraction) : oldfo[3].blue
-          ca = (i.colorAlpha != nil) ? oldfo[3].alpha + ((i.colorAlpha - oldfo[3].alpha) * fraction) : oldfo[3].alpha
+          foColor.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) if !i.opacity.nil?
+          cr = (!i.colorRed.nil?)   ? oldfo[3].red   + ((i.colorRed   - oldfo[3].red)   * fraction) : oldfo[3].red
+          cg = (!i.colorGreen.nil?) ? oldfo[3].green + ((i.colorGreen - oldfo[3].green) * fraction) : oldfo[3].green
+          cb = (!i.colorBlue.nil?)  ? oldfo[3].blue  + ((i.colorBlue  - oldfo[3].blue)  * fraction) : oldfo[3].blue
+          ca = (!i.colorAlpha.nil?) ? oldfo[3].alpha + ((i.colorAlpha - oldfo[3].alpha) * fraction) : oldfo[3].alpha
           foColor.color = Color.new(cr, cg, cb, ca)
         else
-          foGraphic.ox      = oldfo[0] - ((i.bgX - oldfo[0]) * fraction) if i.bgX != nil
-          foGraphic.oy      = oldfo[1] - ((i.bgY - oldfo[1]) * fraction) if i.bgY != nil
-          foGraphic.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) if i.opacity != nil
-          cr = (i.colorRed != nil) ? oldfo[3].red + ((i.colorRed - oldfo[3].red) * fraction) : oldfo[3].red
-          cg = (i.colorGreen != nil) ? oldfo[3].green + ((i.colorGreen - oldfo[3].green) * fraction) : oldfo[3].green
-          cb = (i.colorBlue != nil) ? oldfo[3].blue + ((i.colorBlue - oldfo[3].blue) * fraction) : oldfo[3].blue
-          ca = (i.colorAlpha != nil) ? oldfo[3].alpha + ((i.colorAlpha - oldfo[3].alpha) * fraction) : oldfo[3].alpha
+          foGraphic.ox      = oldfo[0] - ((i.bgX     - oldfo[0]) * fraction) if !i.bgX.nil?
+          foGraphic.oy      = oldfo[1] - ((i.bgY     - oldfo[1]) * fraction) if !i.bgY.nil?
+          foGraphic.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) if !i.opacity.nil?
+          cr = (!i.colorRed.nil?)   ? oldfo[3].red   + ((i.colorRed   - oldfo[3].red)   * fraction) : oldfo[3].red
+          cg = (!i.colorGreen.nil?) ? oldfo[3].green + ((i.colorGreen - oldfo[3].green) * fraction) : oldfo[3].green
+          cb = (!i.colorBlue.nil?)  ? oldfo[3].blue  + ((i.colorBlue  - oldfo[3].blue)  * fraction) : oldfo[3].blue
+          ca = (!i.colorAlpha.nil?) ? oldfo[3].alpha + ((i.colorAlpha - oldfo[3].alpha) * fraction) : oldfo[3].alpha
           foGraphic.color = Color.new(cr, cg, cb, ca)
         end
       end

--- a/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
@@ -298,15 +298,15 @@ class PBAnimTiming
       return text
     when 2
       text = sprintf("[%d] Change BG: @%d", @frame + 1, duration)
-      if !@colorRed.nil? || !@colorGreen.nil? || !@colorBlue.nil? || !@colorAlpha.nil?
+      if !(@colorRed.nil? && @colorGreen.nil? && @colorBlue.nil? && @colorAlpha.nil?)
         text += sprintf(" (color=%s,%s,%s,%s)",
                         (!@colorRed.nil?)   ? @colorRed.to_i   : "-",
                         (!@colorGreen.nil?) ? @colorGreen.to_i : "-",
                         (!@colorBlue.nil?)  ? @colorBlue.to_i  : "-",
                         (!@colorAlpha.nil?) ? @colorAlpha.to_i : "-")
       end
-      text += sprintf(" (opacity=%s)", @opacity.to_i) if !@opacity.nil?
-      if !@bgX.nil? || !@bgY.nil?
+      text += sprintf(" (opacity=%s)", @opacity.to_i) unless @opacity.nil?
+      if !(@bgX.nil? && @bgY.nil?)
         text += sprintf(" (coords=%s,%s)",
                         (!@bgX.nil?) ? @bgX : "-",
                         (!@bgY.nil?) ? @bgY : "-")
@@ -326,15 +326,15 @@ class PBAnimTiming
       return text
     when 4
       text = sprintf("[%d] Change FG: @%d", @frame + 1, duration)
-      if !@colorRed.nil? || !@colorGreen.nil? || !@colorBlue.nil? || !@colorAlpha.nil?
+      if !(@colorRed.nil? && @colorGreen.nil? && @colorBlue.nil? && @colorAlpha.nil?)
         text += sprintf(" (color=%s,%s,%s,%s)",
                         (!@colorRed.nil?)   ? @colorRed.to_i   : "-",
                         (!@colorGreen.nil?) ? @colorGreen.to_i : "-",
                         (!@colorBlue.nil?)  ? @colorBlue.to_i  : "-",
                         (!@colorAlpha.nil?) ? @colorAlpha.to_i : "-")
       end
-      text += sprintf(" (opacity=%s)", @opacity.to_i) if !@opacity.nil?
-      if !@bgX.nil? || !@bgY.nil?
+      text += sprintf(" (opacity=%s)", @opacity.to_i) unless @opacity.nil?
+      if !(@bgX.nil? && @bgY.nil?)
         text += sprintf(" (coords=%s,%s)",
                         (!@bgX.nil?) ? @bgX : "-",
                         (!@bgY.nil?) ? @bgY : "-")
@@ -563,16 +563,16 @@ class PBAnimation < Array
         next if frame < i.frame || frame > i.frame + i.duration
         fraction = (frame - i.frame).to_f / i.duration
         if bgGraphic.bitmap.nil?
-          bgColor.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) if !i.opacity.nil?
+          bgColor.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) unless i.opacity.nil?
           cr = (!i.colorRed.nil?)   ? oldbg[3].red   + ((i.colorRed   - oldbg[3].red)   * fraction) : oldbg[3].red
           cg = (!i.colorGreen.nil?) ? oldbg[3].green + ((i.colorGreen - oldbg[3].green) * fraction) : oldbg[3].green
           cb = (!i.colorBlue.nil?)  ? oldbg[3].blue  + ((i.colorBlue  - oldbg[3].blue)  * fraction) : oldbg[3].blue
           ca = (!i.colorAlpha.nil?) ? oldbg[3].alpha + ((i.colorAlpha - oldbg[3].alpha) * fraction) : oldbg[3].alpha
           bgColor.color = Color.new(cr, cg, cb, ca)
         else
-          bgGraphic.ox      = oldbg[0] - ((i.bgX     - oldbg[0]) * fraction) if !i.bgX.nil?
-          bgGraphic.oy      = oldbg[1] - ((i.bgY     - oldbg[1]) * fraction) if !i.bgY.nil?
-          bgGraphic.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) if !i.opacity.nil?
+          bgGraphic.ox      = oldbg[0] - ((i.bgX     - oldbg[0]) * fraction) unless i.bgX.nil?
+          bgGraphic.oy      = oldbg[1] - ((i.bgY     - oldbg[1]) * fraction) unless i.bgY.nil?
+          bgGraphic.opacity = oldbg[2] + ((i.opacity - oldbg[2]) * fraction) unless i.opacity.nil?
           cr = (!i.colorRed.nil?)   ? oldbg[3].red   + ((i.colorRed   - oldbg[3].red)   * fraction) : oldbg[3].red
           cg = (!i.colorGreen.nil?) ? oldbg[3].green + ((i.colorGreen - oldbg[3].green) * fraction) : oldbg[3].green
           cb = (!i.colorBlue.nil?)  ? oldbg[3].blue  + ((i.colorBlue  - oldbg[3].blue)  * fraction) : oldbg[3].blue
@@ -584,16 +584,16 @@ class PBAnimation < Array
         next if frame < i.frame || frame > i.frame + i.duration
         fraction = (frame - i.frame).to_f / i.duration
         if foGraphic.bitmap.nil?
-          foColor.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) if !i.opacity.nil?
+          foColor.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) unless i.opacity.nil?
           cr = (!i.colorRed.nil?)   ? oldfo[3].red   + ((i.colorRed   - oldfo[3].red)   * fraction) : oldfo[3].red
           cg = (!i.colorGreen.nil?) ? oldfo[3].green + ((i.colorGreen - oldfo[3].green) * fraction) : oldfo[3].green
           cb = (!i.colorBlue.nil?)  ? oldfo[3].blue  + ((i.colorBlue  - oldfo[3].blue)  * fraction) : oldfo[3].blue
           ca = (!i.colorAlpha.nil?) ? oldfo[3].alpha + ((i.colorAlpha - oldfo[3].alpha) * fraction) : oldfo[3].alpha
           foColor.color = Color.new(cr, cg, cb, ca)
         else
-          foGraphic.ox      = oldfo[0] - ((i.bgX     - oldfo[0]) * fraction) if !i.bgX.nil?
-          foGraphic.oy      = oldfo[1] - ((i.bgY     - oldfo[1]) * fraction) if !i.bgY.nil?
-          foGraphic.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) if !i.opacity.nil?
+          foGraphic.ox      = oldfo[0] - ((i.bgX     - oldfo[0]) * fraction) unless i.bgX.nil?
+          foGraphic.oy      = oldfo[1] - ((i.bgY     - oldfo[1]) * fraction) unless i.bgY.nil?
+          foGraphic.opacity = oldfo[2] + ((i.opacity - oldfo[2]) * fraction) unless i.opacity.nil?
           cr = (!i.colorRed.nil?)   ? oldfo[3].red   + ((i.colorRed   - oldfo[3].red)   * fraction) : oldfo[3].red
           cg = (!i.colorGreen.nil?) ? oldfo[3].green + ((i.colorGreen - oldfo[3].green) * fraction) : oldfo[3].green
           cb = (!i.colorBlue.nil?)  ? oldfo[3].blue  + ((i.colorBlue  - oldfo[3].blue)  * fraction) : oldfo[3].blue

--- a/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/007_BattleAnimationPlayer.rb
@@ -492,7 +492,7 @@ class PBAnimation < Array
       next if i.frame != frame
       case i.timingType
       when 0   # Play SE
-        if i.name && i.name != ""
+        if !nil_or_empty?(i&.name)
           pbSEPlay("Anim/" + i.name, i.volume, i.pitch)
         elsif user&.pokemon
           name = GameData::Species.cry_filename_from_pokemon(user.pokemon)
@@ -503,7 +503,7 @@ class PBAnimation < Array
 #          sprite.flash(nil, i.flashDuration * 2) if i.flashScope == 3
 #        end
       when 1   # Set background graphic (immediate)
-        if i.name && i.name != ""
+        if !nil_or_empty?(i&.name)
           bgGraphic.setBitmap("Graphics/Animations/" + i.name)
           bgGraphic.ox      = -i.bgX || 0
           bgGraphic.oy      = -i.bgY || 0
@@ -529,7 +529,7 @@ class PBAnimation < Array
           oldbg[3] = bgGraphic.color.clone || Color.new(0, 0, 0, 0)
         end
       when 3   # Set foreground graphic (immediate)
-        if i.name && i.name != ""
+        if !nil_or_empty?(i&.name)
           foGraphic.setBitmap("Graphics/Animations/" + i.name)
           foGraphic.ox      = -i.bgX || 0
           foGraphic.oy      = -i.bgY || 0

--- a/Data/Scripts/011_Battle/006_Other battle code/008_Battle_AbilityEffects.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/008_Battle_AbilityEffects.rb
@@ -68,7 +68,7 @@ module Battle::AbilityEffects
 
   def self.trigger(hash, *args, ret: false)
     new_ret = hash.trigger(*args)
-    return (new_ret != nil) ? new_ret : ret
+    return (!new_ret.nil? ? new_ret : ret)
   end
 
   #=============================================================================

--- a/Data/Scripts/011_Battle/006_Other battle code/009_Battle_ItemEffects.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/009_Battle_ItemEffects.rb
@@ -52,7 +52,7 @@ module Battle::ItemEffects
 
   def self.trigger(hash, *args, ret: false)
     new_ret = hash.trigger(*args)
-    return (new_ret != nil) ? new_ret : ret
+    return (!new_ret.nil? ? new_ret : ret)
   end
 
   #=============================================================================

--- a/Data/Scripts/011_Battle/006_Other battle code/010_Battle_PokeBallEffects.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/010_Battle_PokeBallEffects.rb
@@ -9,12 +9,12 @@ module Battle::PokeBallEffects
 
   def self.isUnconditional?(ball, battle, battler)
     ret = IsUnconditional.trigger(ball, battle, battler)
-    return (ret != nil) ? ret : false
+    return (!ret.nil? ? ret : false)
   end
 
   def self.modifyCatchRate(ball, catchRate, battle, battler)
     ret = ModifyCatchRate.trigger(ball, catchRate, battle, battler)
-    return (ret != nil) ? ret : catchRate
+    return (!ret.nil? ? ret : catchRate)
   end
 
   def self.onCatch(ball, battle, pkmn)

--- a/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
@@ -92,12 +92,9 @@ end
 #===============================================================================
 class LightEffect
   def initialize(event, viewport = nil, map = nil, filename = nil)
-    @light = IconSprite.new(0, 0, viewport)
-    if !nil_or_empty?(filename) && pbResolveBitmap("Graphics/Pictures/" + filename)
-      @light.setBitmap("Graphics/Pictures/" + filename)
-    else
-      @light.setBitmap("Graphics/Pictures/LE")
-    end
+    @light   = IconSprite.new(0, 0, viewport)
+    filename = (nil_or_empty?(filename) || !pbResolveBitmap("Graphics/Pictures/" + filename) ? "LE" : filename)
+    @light.setBitmap("Graphics/Pictures/" + filename)
     @light.z = 1000
     @event = event
     @map = (map) ? map : $game_map

--- a/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
@@ -93,7 +93,7 @@ end
 class LightEffect
   def initialize(event, viewport = nil, map = nil, filename = nil)
     @light = IconSprite.new(0, 0, viewport)
-    if filename != nil && filename != "" && pbResolveBitmap("Graphics/Pictures/" + filename)
+    if !nil_or_empty?(filename) && pbResolveBitmap("Graphics/Pictures/" + filename)
       @light.setBitmap("Graphics/Pictures/" + filename)
     else
       @light.setBitmap("Graphics/Pictures/LE")

--- a/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
+++ b/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
@@ -149,7 +149,7 @@ def pbPrepareBattle(battle)
     backdrop = "water"   # This applies wherever you are, including in caves
   elsif $game_map.metadata
     back = $game_map.metadata.battle_background
-    backdrop = back if back && back != ""
+    backdrop = back if !nil_or_empty?(back)
   end
   backdrop = "indoor1" if !backdrop
   battle.backdrop = backdrop

--- a/Data/Scripts/012_Overworld/002_Overworld_Metadata.rb
+++ b/Data/Scripts/012_Overworld/002_Overworld_Metadata.rb
@@ -170,9 +170,7 @@ class PokemonMapMetadata
         when 8 then $game_map.events[i[0][1]].turn_up
         end
       end
-      if i[1][3] != nil
-        $game_map.events[i[0][1]].through = i[1][3]
-      end
+      $game_map.events[i[0][1]].through = i[1][3] if !i[1][3].nil?
     end
   end
 end

--- a/Data/Scripts/012_Overworld/004_Overworld_FieldMoves.rb
+++ b/Data/Scripts/012_Overworld/004_Overworld_FieldMoves.rb
@@ -10,7 +10,7 @@ module HiddenMoveHandlers
   def self.addConfirmUseMove(item, proc); ConfirmUseMove.add(item, proc); end
   def self.addUseMove(item, proc);        UseMove.add(item, proc);        end
 
-  def self.hasHandler(item); return !CanUseMove[item].nil? && !UseMove[item].nil?; end
+  def self.hasHandler(item); return !(CanUseMove[item].nil? || UseMove[item].nil?); end
 
   # Returns whether move can be used
   def self.triggerCanUseMove(item, pokemon, showmsg)

--- a/Data/Scripts/012_Overworld/004_Overworld_FieldMoves.rb
+++ b/Data/Scripts/012_Overworld/004_Overworld_FieldMoves.rb
@@ -10,9 +10,7 @@ module HiddenMoveHandlers
   def self.addConfirmUseMove(item, proc); ConfirmUseMove.add(item, proc); end
   def self.addUseMove(item, proc);        UseMove.add(item, proc);        end
 
-  def self.hasHandler(item)
-    return CanUseMove[item] != nil && UseMove[item] != nil
-  end
+  def self.hasHandler(item); return !CanUseMove[item].nil? && !UseMove[item].nil?; end
 
   # Returns whether move can be used
   def self.triggerCanUseMove(item, pokemon, showmsg)

--- a/Data/Scripts/013_Items/001_Item_Utilities.rb
+++ b/Data/Scripts/013_Items/001_Item_Utilities.rb
@@ -16,7 +16,7 @@ module ItemHandlers
   def self.hasUseText(item); return !UseText[item].nil?; end
 
   def self.hasOutHandler(item)                       # Shows "Use" option in Bag
-    return !UseFromBag[item].nil? || !UseInField[item].nil? || !UseOnPokemon[item].nil?
+    return (UseFromBag[item].nil? && UseInField[item].nil? && UseOnPokemon[item].nil?)
   end
 
   # Shows "Register" option in Bag

--- a/Data/Scripts/013_Items/001_Item_Utilities.rb
+++ b/Data/Scripts/013_Items/001_Item_Utilities.rb
@@ -13,37 +13,24 @@ module ItemHandlers
   BattleUseOnBattler  = ItemHandlerHash.new
   BattleUseOnPokemon  = ItemHandlerHash.new
 
-  def self.hasUseText(item)
-    return UseText[item] != nil
-  end
+  def self.hasUseText(item); return !UseText[item].nil?; end
 
   def self.hasOutHandler(item)                       # Shows "Use" option in Bag
-    return UseFromBag[item] != nil || UseInField[item] != nil || UseOnPokemon[item] != nil
+    return !UseFromBag[item].nil? || !UseInField[item].nil? || !UseOnPokemon[item].nil?
   end
 
-  def self.hasUseInFieldHandler(item)           # Shows "Register" option in Bag
-    return UseInField[item] != nil
-  end
+  # Shows "Register" option in Bag
+  def self.hasUseInFieldHandler(item); return !UseInField[item].nil?; end
 
-  def self.hasUseOnPokemon(item)
-    return UseOnPokemon[item] != nil
-  end
+  def self.hasUseOnPokemon(item); return !UseOnPokemon[item].nil?; end
 
-  def self.hasUseOnPokemonMaximum(item)
-    return UseOnPokemonMaximum[item] != nil
-  end
+  def self.hasUseOnPokemonMaximum(item) return !UseOnPokemonMaximum[item].nil?; end
 
-  def self.hasUseInBattle(item)
-    return UseInBattle[item] != nil
-  end
+  def self.hasUseInBattle(item); return !UseInBattle[item].nil?; end
 
-  def self.hasBattleUseOnBattler(item)
-    return BattleUseOnBattler[item] != nil
-  end
+  def self.hasBattleUseOnBattler(item); return !BattleUseOnBattler[item].nil?; end
 
-  def self.hasBattleUseOnPokemon(item)
-    return BattleUseOnPokemon[item] != nil
-  end
+  def self.hasBattleUseOnPokemon(item); return !BattleUseOnPokemon[item].nil?; end
 
   # Returns text to display instead of "Use"
   def self.getUseText(item)

--- a/Data/Scripts/013_Items/004_Item_Phone.rb
+++ b/Data/Scripts/013_Items/004_Item_Phone.rb
@@ -214,10 +214,10 @@ def pbPhoneGenerateCall(phonenum)
   time = pbGetTimeNow
   if PBDayNight.isMorning?(time)
     modcall = pbRandomPhoneItem(phoneData.greetingsMorning)
-    call = modcall if modcall && modcall != ""
+    call = modcall if !nil_or_empty?(modcall)
   elsif PBDayNight.isEvening?(time)
     modcall = pbRandomPhoneItem(phoneData.greetingsEvening)
-    call = modcall if modcall && modcall != ""
+    call = modcall if !nil_or_empty?(modcall)
   end
   call += "\\m"
   if phonenum[4] == 2 || (rand(2) == 0 && phonenum[4] == 3)

--- a/Data/Scripts/013_Items/004_Item_Phone.rb
+++ b/Data/Scripts/013_Items/004_Item_Phone.rb
@@ -89,7 +89,7 @@ def pbFindPhoneTrainer(tr_type, tr_name)        # Ignores whether visible or not
 end
 
 def pbHasPhoneTrainer?(tr_type, tr_name)
-  return pbFindPhoneTrainer(tr_type, tr_name) != nil
+  return !pbFindPhoneTrainer(tr_type, tr_name).nil?
 end
 
 def pbPhoneBattleCount(tr_type, tr_name)

--- a/Data/Scripts/013_Items/006_Item_Mail.rb
+++ b/Data/Scripts/013_Items/006_Item_Mail.rb
@@ -68,13 +68,13 @@ def pbDisplayMail(mail, _bearer = nil)
   shadowForDarkBG  = Color.new(72, 80, 88)
   baseForLightBG   = Color.new(80, 80, 88)
   shadowForLightBG = Color.new(168, 168, 176)
-  if mail.message && mail.message != ""
+  if !nil_or_empty?(mail.message)
     isDark = isDarkBackground(sprites["card"].bitmap, Rect.new(48, 48, Graphics.width - 96, 32 * 7))
     drawTextEx(overlay, 48, 52, Graphics.width - (48 * 2), 7, mail.message,
                (isDark) ? baseForDarkBG : baseForLightBG,
                (isDark) ? shadowForDarkBG : shadowForLightBG)
   end
-  if mail.sender && mail.sender != ""
+  if !nil_or_empty?(mail.sender)
     isDark = isDarkBackground(sprites["card"].bitmap, Rect.new(336, 322, 144, 32 * 1))
     drawTextEx(overlay, 336, 326, 144, 1, mail.sender,
                (isDark) ? baseForDarkBG : baseForLightBG,

--- a/Data/Scripts/013_Items/006_Item_Mail.rb
+++ b/Data/Scripts/013_Items/006_Item_Mail.rb
@@ -99,7 +99,7 @@ def pbWriteMail(item, pkmn, pkmnid, scene)
   loop do
     message = pbMessageFreeText(_INTL("Please enter a message (max. 250 characters)."),
                                 "", false, 250, Graphics.width) { scene.pbUpdate }
-    if message != ""
+    if !message.empty?
       # Store mail if a message was written
       poke1 = poke2 = nil
       if $player.party[pkmnid + 2]

--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -143,7 +143,7 @@ class Pokemon
     return @forced_form if !@forced_form.nil?
     return @form if $game_temp.in_battle || $game_temp.in_storage
     calc_form = MultipleForms.call("getForm", self)
-    self.form = calc_form if !calc_form.nil? && calc_form != @form
+    self.form = calc_form unless calc_form.nil? || calc_form == @form
     return @form
   end
 
@@ -587,9 +587,7 @@ class Pokemon
   # removes the held mail.
   # @param mail [Mail, nil] mail to be held by this Pokémon
   def mail=(mail)
-    if !mail.nil? && !mail.is_a?(Mail)
-      raise ArgumentError, _INTL('Invalid value {1} given', mail.inspect)
-    end
+    validate mail => [NilClass, Mail]
     @mail = mail
   end
 

--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -143,7 +143,7 @@ class Pokemon
     return @forced_form if !@forced_form.nil?
     return @form if $game_temp.in_battle || $game_temp.in_storage
     calc_form = MultipleForms.call("getForm", self)
-    self.form = calc_form if calc_form != nil && calc_form != @form
+    self.form = calc_form if !calc_form.nil? && calc_form != @form
     return @form
   end
 

--- a/Data/Scripts/014_Pokemon/002_Pokemon_MegaEvolution.rb
+++ b/Data/Scripts/014_Pokemon/002_Pokemon_MegaEvolution.rb
@@ -73,10 +73,6 @@ class Pokemon
 
   def makeUnprimal
     v = MultipleForms.call("getUnprimalForm", self)
-    if !v.nil?
-      self.form = v
-    elsif primal?
-      self.form = 0
-    end
+    self.form = (v.nil? ? 0 : v)
   end
 end

--- a/Data/Scripts/016_UI/001_Non-interactive UI/006_UI_HallOfFame.rb
+++ b/Data/Scripts/016_UI/001_Non-interactive UI/006_UI_HallOfFame.rb
@@ -64,7 +64,7 @@ class HallOfFame_Scene
 
   def pbStartSceneEntry
     pbStartScene
-    @useMusic = (ENTRYMUSIC && ENTRYMUSIC != "")
+    @useMusic = !nil_or_empty?(ENTRYMUSIC)
     pbBGMPlay(ENTRYMUSIC) if @useMusic
     saveHallEntry
     @xmovement = []

--- a/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
+++ b/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
@@ -419,7 +419,7 @@ class PokemonPokedex_Scene
     dexname = _INTL("Pokédex")
     if $player.pokedex.dexes_count > 1
       thisdex = Settings.pokedex_names[pbGetSavePositionIndex]
-      dexname = (thisdex.is_a?(Array)) ? thisdex[0] : thisdex if !thisdex.nil?
+      dexname = (thisdex.is_a?(Array)) ? thisdex[0] : thisdex unless thisdex.nil?
     end
     textpos = [
       [dexname, Graphics.width / 2, -2, 2, Color.new(248, 248, 248), Color.new(0, 0, 0)]
@@ -1164,40 +1164,40 @@ class PokemonPokedex_Scene
         case index
         when 0   # Choose sort order
           newparam = pbDexSearchCommands(0, [params[0]], index)
-          params[0] = newparam[0] if !newparam.nil?
+          params[0] = newparam[0] unless newparam.nil?
           pbRefreshDexSearch(params, index)
         when 1   # Filter by name
           newparam = pbDexSearchCommands(1, [params[1]], index)
-          params[1] = newparam[0] if !newparam.nil?
+          params[1] = newparam[0] unless newparam.nil?
           pbRefreshDexSearch(params, index)
         when 2   # Filter by type
           newparam = pbDexSearchCommands(2, [params[2], params[3]], index)
-          if !newparam.nil?
+          unless newparam.nil?
             params[2] = newparam[0]
             params[3] = newparam[1]
           end
           pbRefreshDexSearch(params, index)
         when 3   # Filter by height range
           newparam = pbDexSearchCommands(3, [params[4], params[5]], index)
-          if !newparam.nil?
+          unless newparam.nil?
             params[4] = newparam[0]
             params[5] = newparam[1]
           end
           pbRefreshDexSearch(params, index)
         when 4   # Filter by weight range
           newparam = pbDexSearchCommands(4, [params[6], params[7]], index)
-          if !newparam.nil?
+          unless newparam.nil?
             params[6] = newparam[0]
             params[7] = newparam[1]
           end
           pbRefreshDexSearch(params, index)
         when 5   # Filter by color filter
           newparam = pbDexSearchCommands(5, [params[8]], index)
-          params[8] = newparam[0] if !newparam.nil?
+          params[8] = newparam[0] unless newparam.nil?
           pbRefreshDexSearch(params, index)
         when 6   # Filter by shape
           newparam = pbDexSearchCommands(6, [params[9]], index)
-          params[9] = newparam[0] if !newparam.nil?
+          params[9] = newparam[0] unless newparam.nil?
           pbRefreshDexSearch(params, index)
         when 7   # Clear filters
           10.times do |i|

--- a/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
+++ b/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
@@ -419,9 +419,7 @@ class PokemonPokedex_Scene
     dexname = _INTL("Pokédex")
     if $player.pokedex.dexes_count > 1
       thisdex = Settings.pokedex_names[pbGetSavePositionIndex]
-      if thisdex != nil
-        dexname = (thisdex.is_a?(Array)) ? thisdex[0] : thisdex
-      end
+      dexname = (thisdex.is_a?(Array)) ? thisdex[0] : thisdex if !thisdex.nil?
     end
     textpos = [
       [dexname, Graphics.width / 2, -2, 2, Color.new(248, 248, 248), Color.new(0, 0, 0)]
@@ -1166,40 +1164,40 @@ class PokemonPokedex_Scene
         case index
         when 0   # Choose sort order
           newparam = pbDexSearchCommands(0, [params[0]], index)
-          params[0] = newparam[0] if newparam != nil
+          params[0] = newparam[0] if !newparam.nil?
           pbRefreshDexSearch(params, index)
         when 1   # Filter by name
           newparam = pbDexSearchCommands(1, [params[1]], index)
-          params[1] = newparam[0] if newparam != nil
+          params[1] = newparam[0] if !newparam.nil?
           pbRefreshDexSearch(params, index)
         when 2   # Filter by type
           newparam = pbDexSearchCommands(2, [params[2], params[3]], index)
-          if newparam != nil
+          if !newparam.nil?
             params[2] = newparam[0]
             params[3] = newparam[1]
           end
           pbRefreshDexSearch(params, index)
         when 3   # Filter by height range
           newparam = pbDexSearchCommands(3, [params[4], params[5]], index)
-          if newparam != nil
+          if !newparam.nil?
             params[4] = newparam[0]
             params[5] = newparam[1]
           end
           pbRefreshDexSearch(params, index)
         when 4   # Filter by weight range
           newparam = pbDexSearchCommands(4, [params[6], params[7]], index)
-          if newparam != nil
+          if !newparam.nil?
             params[6] = newparam[0]
             params[7] = newparam[1]
           end
           pbRefreshDexSearch(params, index)
         when 5   # Filter by color filter
           newparam = pbDexSearchCommands(5, [params[8]], index)
-          params[8] = newparam[0] if newparam != nil
+          params[8] = newparam[0] if !newparam.nil?
           pbRefreshDexSearch(params, index)
         when 6   # Filter by shape
           newparam = pbDexSearchCommands(6, [params[9]], index)
-          params[9] = newparam[0] if newparam != nil
+          params[9] = newparam[0] if !newparam.nil?
           pbRefreshDexSearch(params, index)
         when 7   # Clear filters
           10.times do |i|

--- a/Data/Scripts/016_UI/005_UI_Party.rb
+++ b/Data/Scripts/016_UI/005_UI_Party.rb
@@ -592,9 +592,7 @@ class PokemonParty_Scene
     helpwindow.visible = true
   end
 
-  def pbHasAnnotations?
-    return @sprites["pokemon0"].text != nil
-  end
+  def pbHasAnnotations?; return !@sprites["pokemon0"].text.nil?; end
 
   def pbAnnotate(annot)
     Settings::MAX_PARTY_SIZE.times do |i|

--- a/Data/Scripts/016_UI/006_UI_Summary.rb
+++ b/Data/Scripts/016_UI/006_UI_Summary.rb
@@ -510,10 +510,10 @@ class PokemonSummary_Scene
     # Write map name egg was received on
     mapname = pbGetMapNameFromId(@pokemon.obtain_map)
     mapname = @pokemon.obtain_text if @pokemon.obtain_text && !@pokemon.obtain_text.empty?
-    if !nil_or_empty?(mapname)
-      memo += _INTL("<c3=404040,B0B0B0>A mysterious Pokémon Egg received from <c3=F83820,E09890>{1}<c3=404040,B0B0B0>.\n", mapname)
-    else
+    if nil_or_empty?(mapname)
       memo += _INTL("<c3=404040,B0B0B0>A mysterious Pokémon Egg.\n", mapname)
+    else
+      memo += _INTL("<c3=404040,B0B0B0>A mysterious Pokémon Egg received from <c3=F83820,E09890>{1}<c3=404040,B0B0B0>.\n", mapname)
     end
     memo += "\n" # Empty line
     # Write Egg Watch blurb

--- a/Data/Scripts/016_UI/006_UI_Summary.rb
+++ b/Data/Scripts/016_UI/006_UI_Summary.rb
@@ -510,7 +510,7 @@ class PokemonSummary_Scene
     # Write map name egg was received on
     mapname = pbGetMapNameFromId(@pokemon.obtain_map)
     mapname = @pokemon.obtain_text if @pokemon.obtain_text && !@pokemon.obtain_text.empty?
-    if mapname && mapname != ""
+    if !nil_or_empty?(mapname)
       memo += _INTL("<c3=404040,B0B0B0>A mysterious Pokémon Egg received from <c3=F83820,E09890>{1}<c3=404040,B0B0B0>.\n", mapname)
     else
       memo += _INTL("<c3=404040,B0B0B0>A mysterious Pokémon Egg.\n", mapname)
@@ -556,7 +556,7 @@ class PokemonSummary_Scene
                _INTL("Traded at Lv. {1}.", @pokemon.obtain_level),
                "",
                _INTL("Had a fateful encounter at Lv. {1}.", @pokemon.obtain_level)][@pokemon.obtain_method]
-    memo += sprintf("<c3=404040,B0B0B0>%s\n", mettext) if mettext && mettext != ""
+    memo += sprintf("<c3=404040,B0B0B0>%s\n", mettext) if !nil_or_empty?(mettext)
     # If Pokémon was hatched, write when and where it hatched
     if @pokemon.obtain_method == 1
       if @pokemon.timeEggHatched

--- a/Data/Scripts/016_UI/022_UI_PurifyChamber.rb
+++ b/Data/Scripts/016_UI/022_UI_PurifyChamber.rb
@@ -126,7 +126,7 @@ class PurifyChamberSet
     unless value&.shadowPokemon?
       @list.insert(index + 1, value)
       @list.compact!
-      @facing += 1 if @facing > index && value != nil
+      @facing += 1 if @facing > index && !value.nil?
       @facing = [[@facing, @list.length - 1].min, 0].max
     end
   end

--- a/Data/Scripts/016_UI/023_UI_MysteryGift.rb
+++ b/Data/Scripts/016_UI/023_UI_MysteryGift.rb
@@ -33,7 +33,7 @@ def pbEditMysteryGift(type, item, id = 0, giftname = "")
           break
         elsif command == commands.length - 1
           obtainname = pbMessageFreeText(_INTL("Enter a phrase."), "", false, 30)
-          if obtainname != ""
+          if !obtainname.empty?
             item.obtain_text = obtainname
             break
           end
@@ -84,7 +84,7 @@ def pbEditMysteryGift(type, item, id = 0, giftname = "")
     end
     loop do
       newgiftname = pbMessageFreeText(_INTL("Enter a name for the gift."), giftname, false, 250)
-      if newgiftname != ""
+      if !newgiftname.empty?
         giftname = newgiftname
         break
       end

--- a/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
+++ b/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
@@ -830,7 +830,7 @@ class TriadScreen
             y = i / @width
             square.type = @board[i].type
             flips = flipBoard(x, y, square)
-            scores.push([cardIndex, x, y, flips.length]) if !flips.nil?
+            scores.push([cardIndex, x, y, flips.length]) unless flips.nil?
           end
         end
         # Sort by number of flips

--- a/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
+++ b/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
@@ -655,7 +655,7 @@ class TriadScreen
     panels[7] = (@wrapAround ? 0 : @height - 1) if panels[7] > @height - 1   # bottom
     attacker = attackerParam.nil? ? @board[(y * @width) + x] : attackerParam
     flips = []
-    return nil if attackerParam != nil && @board[(y * @width) + x].owner != 0
+    return nil if !attackerParam.nil? && @board[(y * @width) + x].owner != 0
     return nil if !attacker.card || attacker.owner == 0
     4.times do |i|
       defenderX = panels[i * 2]
@@ -830,9 +830,7 @@ class TriadScreen
             y = i / @width
             square.type = @board[i].type
             flips = flipBoard(x, y, square)
-            if flips != nil
-              scores.push([cardIndex, x, y, flips.length])
-            end
+            scores.push([cardIndex, x, y, flips.length]) if !flips.nil?
           end
         end
         # Sort by number of flips

--- a/Data/Scripts/018_Alternate battle modes/001_Battle Frontier/002_Challenge_Data.rb
+++ b/Data/Scripts/018_Alternate battle modes/001_Battle Frontier/002_Challenge_Data.rb
@@ -44,7 +44,7 @@ def pbEntryScreen(*arg)
     # Set party
     pbBattleChallenge.setParty(ret) if ret
     # Continue (return true) if Pokémon were chosen
-    retval = (ret != nil && ret.length > 0)
+    retval = (!ret.nil? && ret.length > 0)
   }
   return retval
 end

--- a/Data/Scripts/018_Alternate battle modes/001_Battle Frontier/002_Challenge_Data.rb
+++ b/Data/Scripts/018_Alternate battle modes/001_Battle Frontier/002_Challenge_Data.rb
@@ -169,7 +169,7 @@ class PBPokemon
     c3 = (@nature) ? GameData::Nature.get(@nature).id : ""
     evlist = ""
     @ev.each do |stat|
-      evlist += "," if evlist != ""
+      evlist += "," if !evlist.empty?
       evlist += stat.real_name_brief
     end
     c4 = (@move1) ? GameData::Move.get(@move1).id : ""

--- a/Data/Scripts/019_Utilities/003_Utilities_BattleAudio.rb
+++ b/Data/Scripts/019_Utilities/003_Utilities_BattleAudio.rb
@@ -9,12 +9,12 @@ def pbGetWildBattleBGM(_wildParty)   # wildParty is an array of Pokémon objects
   if !ret
     # Check map metadata
     music = $game_map.metadata&.wild_battle_BGM
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.wild_battle_BGM
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   ret = pbStringToAudioFile("Battle wild") if !ret
   return ret
@@ -28,12 +28,12 @@ def pbGetWildVictoryME
   if !ret
     # Check map metadata
     music = $game_map.metadata&.wild_victory_ME
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.wild_victory_ME
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   ret = pbStringToAudioFile("Battle victory") if !ret
   ret.name = "../../Audio/ME/" + ret.name
@@ -48,12 +48,12 @@ def pbGetWildCaptureME
   if !ret
     # Check map metadata
     music = $game_map.metadata&.wild_capture_ME
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.wild_capture_ME
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   ret = pbStringToAudioFile("Battle capture success") if !ret
   ret.name = "../../Audio/ME/" + ret.name
@@ -81,16 +81,16 @@ def pbGetTrainerBattleBGM(trainer)   # can be a Player, NPCTrainer or an array o
     trainer_type_data = GameData::TrainerType.get(t.trainer_type)
     music = trainer_type_data.battle_BGM if trainer_type_data.battle_BGM
   end
-  ret = pbStringToAudioFile(music) if music && music != ""
+  ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   if !ret
     # Check map metadata
     music = $game_map.metadata&.trainer_battle_BGM
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.trainer_battle_BGM
-    if music && music != ""
+    if !nil_or_empty?(music)
       ret = pbStringToAudioFile(music)
     end
   end
@@ -107,12 +107,12 @@ def pbGetTrainerBattleBGMFromType(trainertype)
   if !ret
     # Check map metadata
     music = $game_map.metadata&.trainer_battle_BGM
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.trainer_battle_BGM
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   ret = pbStringToAudioFile("Battle trainer") if !ret
   return ret
@@ -129,18 +129,18 @@ def pbGetTrainerVictoryME(trainer)   # can be a Player, NPCTrainer or an array o
     music = trainer_type_data.victory_ME if trainer_type_data.victory_ME
   end
   ret = nil
-  if music && music != ""
+  if !nil_or_empty?(music)
     ret = pbStringToAudioFile(music)
   end
   if !ret
     # Check map metadata
     music = $game_map.metadata&.trainer_victory_ME
-    ret = pbStringToAudioFile(music) if music && music != ""
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.trainer_victory_ME
-    if music && music != ""
+    if !nil_or_empty?(music)
       ret = pbStringToAudioFile(music)
     end
   end

--- a/Data/Scripts/019_Utilities/003_Utilities_BattleAudio.rb
+++ b/Data/Scripts/019_Utilities/003_Utilities_BattleAudio.rb
@@ -2,9 +2,7 @@
 # Load various wild battle music
 #===============================================================================
 def pbGetWildBattleBGM(_wildParty)   # wildParty is an array of Pokémon objects
-  if $PokemonGlobal.nextBattleBGM
-    return $PokemonGlobal.nextBattleBGM.clone
-  end
+  return $PokemonGlobal.nextBattleBGM.clone if $PokemonGlobal.nextBattleBGM
   ret = nil
   if !ret
     # Check map metadata
@@ -21,9 +19,7 @@ def pbGetWildBattleBGM(_wildParty)   # wildParty is an array of Pokémon objects
 end
 
 def pbGetWildVictoryME
-  if $PokemonGlobal.nextBattleME
-    return $PokemonGlobal.nextBattleME.clone
-  end
+  return $PokemonGlobal.nextBattleME.clone if $PokemonGlobal.nextBattleME
   ret = nil
   if !ret
     # Check map metadata
@@ -41,9 +37,7 @@ def pbGetWildVictoryME
 end
 
 def pbGetWildCaptureME
-  if $PokemonGlobal.nextBattleCaptureME
-    return $PokemonGlobal.nextBattleCaptureME.clone
-  end
+  return $PokemonGlobal.nextBattleCaptureME.clone if $PokemonGlobal.nextBattleCaptureME
   ret = nil
   if !ret
     # Check map metadata
@@ -71,9 +65,7 @@ def pbPlayTrainerIntroME(trainer_type)
 end
 
 def pbGetTrainerBattleBGM(trainer)   # can be a Player, NPCTrainer or an array of them
-  if $PokemonGlobal.nextBattleBGM
-    return $PokemonGlobal.nextBattleBGM.clone
-  end
+  return $PokemonGlobal.nextBattleBGM.clone if $PokemonGlobal.nextBattleBGM
   ret = nil
   music = nil
   trainerarray = (trainer.is_a?(Array)) ? trainer : [trainer]
@@ -90,18 +82,14 @@ def pbGetTrainerBattleBGM(trainer)   # can be a Player, NPCTrainer or an array o
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.trainer_battle_BGM
-    if !nil_or_empty?(music)
-      ret = pbStringToAudioFile(music)
-    end
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   ret = pbStringToAudioFile("Battle trainer") if !ret
   return ret
 end
 
 def pbGetTrainerBattleBGMFromType(trainertype)
-  if $PokemonGlobal.nextBattleBGM
-    return $PokemonGlobal.nextBattleBGM.clone
-  end
+  return $PokemonGlobal.nextBattleBGM.clone if $PokemonGlobal.nextBattleBGM
   trainer_type_data = GameData::TrainerType.get(trainertype)
   ret = trainer_type_data.battle_BGM if trainer_type_data.battle_BGM
   if !ret
@@ -119,9 +107,7 @@ def pbGetTrainerBattleBGMFromType(trainertype)
 end
 
 def pbGetTrainerVictoryME(trainer)   # can be a Player, NPCTrainer or an array of them
-  if $PokemonGlobal.nextBattleME
-    return $PokemonGlobal.nextBattleME.clone
-  end
+  return $PokemonGlobal.nextBattleME.clone if $PokemonGlobal.nextBattleME
   music = nil
   trainerarray = (trainer.is_a?(Array)) ? trainer : [trainer]
   trainerarray.each do |t|
@@ -129,9 +115,7 @@ def pbGetTrainerVictoryME(trainer)   # can be a Player, NPCTrainer or an array o
     music = trainer_type_data.victory_ME if trainer_type_data.victory_ME
   end
   ret = nil
-  if !nil_or_empty?(music)
-    ret = pbStringToAudioFile(music)
-  end
+  ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   if !ret
     # Check map metadata
     music = $game_map.metadata&.trainer_victory_ME
@@ -140,9 +124,7 @@ def pbGetTrainerVictoryME(trainer)   # can be a Player, NPCTrainer or an array o
   if !ret
     # Check global metadata
     music = GameData::Metadata.get.trainer_victory_ME
-    if !nil_or_empty?(music)
-      ret = pbStringToAudioFile(music)
-    end
+    ret = pbStringToAudioFile(music) if !nil_or_empty?(music)
   end
   ret = pbStringToAudioFile("Battle victory") if !ret
   ret.name = "../../Audio/ME/" + ret.name

--- a/Data/Scripts/020_Debug/001_Editor_Utilities.rb
+++ b/Data/Scripts/020_Debug/001_Editor_Utilities.rb
@@ -48,7 +48,7 @@ def pbAllocateAnimation(animations, name)
 #      # use animation with same name
 #      return i
 #    end
-    if anim.length == 1 && anim[0].length == 2 && anim.name == ""
+    if anim.length == 1 && anim[0].length == 2 && anim.name.empty?
       # assume empty
       return i
     end

--- a/Data/Scripts/020_Debug/002_Animation editor/001_AnimEditor_SceneElements.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/001_AnimEditor_SceneElements.rb
@@ -479,7 +479,7 @@ class AnimationCanvas < Sprite
   def loadAnimation(anim)
     @animation = anim
     @animbitmap&.dispose
-    if @animation.graphic == ""
+    if @animation.graphic.empty?
       @animbitmap = nil
     else
       begin

--- a/Data/Scripts/020_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
@@ -67,7 +67,7 @@ def pbImportAnim(animations, canvas, animwin)
       end
       graphic = animations[animations.selected].graphic
       graphic = "Graphics/Animations/#{graphic}"
-      if graphic && graphic != "" && !FileTest.image_exist?(graphic)
+      if !nil_or_empty?(graphic) && !FileTest.image_exist?(graphic)
         pbMessage(_INTL("The animation file {1} was not found. The animation will load anyway.", graphic))
       end
       canvas.loadAnimation(animations[animations.selected])

--- a/Data/Scripts/020_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
@@ -23,7 +23,7 @@ end
 
 def pbExportAnim(animations)
   filename = pbMessageFreeText(_INTL("Enter a filename."), "", false, 32)
-  if filename != ""
+  if !filename.empty?
     begin
       filename += ".anm"
       File.open(filename, "wb") { |f|

--- a/Data/Scripts/020_Debug/002_Animation editor/005_AnimEditor_Functions.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/005_AnimEditor_Functions.rb
@@ -644,13 +644,13 @@ def pbEditBG(canvas, timing)
   maxsizewindow.addOptionalSlider(_INTL("Alpha:"), 0, 255, timing.colorAlpha || 0)
   maxsizewindow.addButton(_INTL("OK"))
   maxsizewindow.addButton(_INTL("Cancel"))
-  maxsizewindow.controls[1].checked = (timing.bgX != nil)
-  maxsizewindow.controls[2].checked = (timing.bgY != nil)
-  maxsizewindow.controls[3].checked = (timing.opacity != nil)
-  maxsizewindow.controls[4].checked = (timing.colorRed != nil)
-  maxsizewindow.controls[5].checked = (timing.colorGreen != nil)
-  maxsizewindow.controls[6].checked = (timing.colorBlue != nil)
-  maxsizewindow.controls[7].checked = (timing.colorAlpha != nil)
+  maxsizewindow.controls[1].checked = !timing.bgX.nil?
+  maxsizewindow.controls[2].checked = !timing.bgY.nil?
+  maxsizewindow.controls[3].checked = !timing.opacity.nil?
+  maxsizewindow.controls[4].checked = !timing.colorRed.nil?
+  maxsizewindow.controls[5].checked = !timing.colorGreen.nil?
+  maxsizewindow.controls[6].checked = !timing.colorBlue.nil?
+  maxsizewindow.controls[7].checked = !timing.colorAlpha.nil?
   maxsizewindow.opacity = 200
   maxsizewindow.viewport = canvas.viewport
   loop do

--- a/Data/Scripts/020_Debug/002_Animation editor/005_AnimEditor_Functions.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/005_AnimEditor_Functions.rb
@@ -504,8 +504,8 @@ def pbTimingList(canvas)
 end
 
 def pbSelectSE(canvas, audio)
-  filename = (!nil_or_empty?(audio.name) ? audio.name : "")
-  displayname = (!nil_or_empty?(filename) ? filename : _INTL("<user's cry>"))
+  filename    = (nil_or_empty?(audio.name) ? "" : audio.name)
+  displayname = (nil_or_empty?(filename)   ? _INTL("<user's cry>") : filename)
   animfiles = []
   ret = false
   pbRgssChdir(File.join("Audio", "SE", "Anim")) {

--- a/Data/Scripts/020_Debug/002_Animation editor/005_AnimEditor_Functions.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/005_AnimEditor_Functions.rb
@@ -504,8 +504,8 @@ def pbTimingList(canvas)
 end
 
 def pbSelectSE(canvas, audio)
-  filename = (audio.name != "") ? audio.name : ""
-  displayname = (filename != "") ? filename : _INTL("<user's cry>")
+  filename = (!nil_or_empty?(audio.name) ? audio.name : "")
+  displayname = (!nil_or_empty?(filename) ? filename : _INTL("<user's cry>"))
   animfiles = []
   ret = false
   pbRgssChdir(File.join("Audio", "SE", "Anim")) {
@@ -558,7 +558,7 @@ def pbSelectSE(canvas, audio)
     end
     if Input.trigger?(Input::USE) && animfiles.length > 0
       filename = (cmdwin.index == 0) ? "" : cmdwin.commands[cmdwin.index]
-      displayname = (filename != "") ? filename : _INTL("<user's cry>")
+      displayname = (!nil_or_empty?(filename) ? filename : _INTL("<user's cry>"))
       maxsizewindow.controls[0].text = _INTL("File: \"{1}\"", displayname)
     elsif Input.trigger?(Input::BACK)
       break

--- a/Data/Scripts/020_Debug/002_Editor_DataTypes.rb
+++ b/Data/Scripts/020_Debug/002_Editor_DataTypes.rb
@@ -147,7 +147,7 @@ module BooleanProperty2
   end
 
   def self.format(value)
-    return (value) ? _INTL("True") : (value != nil) ? _INTL("False") : "-"
+    return (value) ? _INTL("True") : (!value.nil?) ? _INTL("False") : "-"
   end
 end
 

--- a/Data/Scripts/020_Debug/002_Editor_DataTypes.rb
+++ b/Data/Scripts/020_Debug/002_Editor_DataTypes.rb
@@ -359,7 +359,7 @@ end
 module BGMProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, MusicFileLister.new(true, oldsetting))
-    return (chosenmap && chosenmap != "") ? chosenmap : oldsetting
+    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
   end
 
   def self.format(value)
@@ -372,7 +372,7 @@ end
 module MEProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, MusicFileLister.new(false, oldsetting))
-    return (chosenmap && chosenmap != "") ? chosenmap : oldsetting
+    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
   end
 
   def self.format(value)
@@ -385,7 +385,7 @@ end
 module WindowskinProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, GraphicsLister.new("Graphics/Windowskins/", oldsetting))
-    return (chosenmap && chosenmap != "") ? chosenmap : oldsetting
+    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
   end
 
   def self.format(value)
@@ -653,7 +653,7 @@ end
 module CharacterProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, GraphicsLister.new("Graphics/Characters/", oldsetting))
-    return (chosenmap && chosenmap != "") ? chosenmap : oldsetting
+    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
   end
 
   def self.format(value)

--- a/Data/Scripts/020_Debug/002_Editor_DataTypes.rb
+++ b/Data/Scripts/020_Debug/002_Editor_DataTypes.rb
@@ -359,7 +359,7 @@ end
 module BGMProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, MusicFileLister.new(true, oldsetting))
-    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
+    return (nil_or_empty?(chosenmap) ? oldsetting : chosenmap)
   end
 
   def self.format(value)
@@ -372,7 +372,7 @@ end
 module MEProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, MusicFileLister.new(false, oldsetting))
-    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
+    return (nil_or_empty?(chosenmap) ? oldsetting : chosenmap)
   end
 
   def self.format(value)
@@ -385,7 +385,7 @@ end
 module WindowskinProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, GraphicsLister.new("Graphics/Windowskins/", oldsetting))
-    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
+    return (nil_or_empty?(chosenmap) ? oldsetting : chosenmap)
   end
 
   def self.format(value)
@@ -653,7 +653,7 @@ end
 module CharacterProperty
   def self.set(settingname, oldsetting)
     chosenmap = pbListScreen(settingname, GraphicsLister.new("Graphics/Characters/", oldsetting))
-    return (!nil_or_empty?(chosenmap) ? chosenmap : oldsetting)
+    return (nil_or_empty?(chosenmap) ? oldsetting : chosenmap)
   end
 
   def self.format(value)

--- a/Data/Scripts/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
+++ b/Data/Scripts/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
@@ -573,18 +573,18 @@ def pbExportAllAnimations
         File.open("Animations/#{safename}/#{safename}.anm", "wb") { |f|
           f.write(dumpBase64Anim(anim))
         }
-        if anim.graphic && anim.graphic != ""
+        if !nil_or_empty?(anim.graphic)
           graphicname = RTP.getImagePath("Graphics/Animations/" + anim.graphic)
           pbSafeCopyFile(graphicname, "Animations/#{safename}/" + File.basename(graphicname))
         end
         anim.timing.each do |timing|
           if !timing.timingType || timing.timingType == 0
-            if timing.name && timing.name != ""
+            if !nil_or_empty?(timing.name)
               audioName = RTP.getAudioPath("Audio/SE/Anim/" + timing.name)
               pbSafeCopyFile(audioName, "Animations/#{safename}/" + File.basename(audioName))
             end
           elsif timing.timingType == 1 || timing.timingType == 3
-            if timing.name && timing.name != ""
+            if !nil_or_empty?(timing.name)
               graphicname = RTP.getImagePath("Graphics/Animations/" + timing.name)
               pbSafeCopyFile(graphicname, "Animations/#{safename}/" + File.basename(graphicname))
             end
@@ -648,14 +648,14 @@ def pbImportAllAnimations
           textdata.name = File.basename(folder) if textdata.name == ""
           textdata.id = -1   # This is not an RPG Maker XP animation
           pbConvertAnimToNewFormat(textdata)
-          if textdata.graphic && textdata.graphic != "" &&
+          if !nil_or_empty?(textdata.graphic) &&
              !safeExists?(folder + "/" + textdata.graphic) &&
              !FileTest.image_exist?("Graphics/Animations/" + textdata.graphic)
             textdata.graphic = ""
             missingFiles.push(textdata.graphic)
           end
           textdata.timing.each do |timing|
-            if timing.name && timing.name != "" &&
+            if !nil_or_empty?(timing.name) &&
                !safeExists?(folder + "/" + timing.name) &&
                !FileTest.audio_exist?("Audio/SE/Anim/" + timing.name)
               timing.name = ""
@@ -741,7 +741,7 @@ def pbCheckTileValidity(tile_id, map, tilesets, passages)
     # Check for defined autotile
     autotile_id = (tile_id / 48) - 1
     autotile_name = tilesets[map.tileset_id].autotile_names[autotile_id]
-    return true if autotile_name && autotile_name != ""
+    return true if !nil_or_empty?(autotile_name)
   else
     # Check for tileset data
     return true if passages[tile_id]

--- a/Data/Scripts/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
+++ b/Data/Scripts/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
@@ -21,7 +21,7 @@ def pbWarpToMap
       next if !map.passableStrict?(x, y, 0, $game_player)
       blocked = false
       map.events.values.each do |event|
-        if event.at_coordinate?(x, y) && !event.through && event.character_name != ""
+        if event.at_coordinate?(x, y) && !event.through && !event.character_name.empty?
           blocked = true
         end
       end
@@ -565,7 +565,7 @@ def pbExportAllAnimations
     if animations
       msgwindow = pbCreateMessageWindow
       animations.each do |anim|
-        next if !anim || anim.length == 0 || anim.name == ""
+        next if !anim || anim.length == 0 || anim.name.empty?
         pbMessageDisplay(msgwindow, anim.name, false)
         Graphics.update
         safename = anim.name.gsub(/\W/, "_")
@@ -645,7 +645,7 @@ def pbImportAllAnimations
         if textdata.is_a?(PBAnimation)
           index = pbAllocateAnimation(animations, textdata.name)
           missingFiles = []
-          textdata.name = File.basename(folder) if textdata.name == ""
+          textdata.name = File.basename(folder) if textdata.name.empty?
           textdata.id = -1   # This is not an RPG Maker XP animation
           pbConvertAnimToNewFormat(textdata)
           if !nil_or_empty?(textdata.graphic) &&

--- a/Data/Scripts/021_Compiler/003_Compiler_WritePBS.rb
+++ b/Data/Scripts/021_Compiler/003_Compiler_WritePBS.rb
@@ -28,7 +28,7 @@ module Compiler
         f.write(sprintf("[%d]\r\n", i))
         rname = pbGetMessage(MessageTypes::RegionNames, i)
         f.write(sprintf("Name = %s\r\nFilename = %s\r\n",
-                        (rname && rname != "") ? rname : _INTL("Unnamed"),
+                        (!nil_or_empty?(rname)) ? rname : _INTL("Unnamed"),
                         csvQuote((map[1].is_a?(Array)) ? map[1][0] : map[1])))
         map[2].each do |loc|
           f.write("Point = ")

--- a/Data/Scripts/021_Compiler/003_Compiler_WritePBS.rb
+++ b/Data/Scripts/021_Compiler/003_Compiler_WritePBS.rb
@@ -336,12 +336,10 @@ module Compiler
             evo_type_data = GameData::Evolution.get(evo[1])
             param_type = evo_type_data.parameter
             f.write(sprintf("%s,%s,", evo[0], evo_type_data.id.to_s))
-            if !param_type.nil?
-              if param_type.is_a?(Symbol) && !GameData.const_defined?(param_type)
-                f.write(getConstantName(param_type, evo[2]))
-              else
-                f.write(evo[2].to_s)
-              end
+            if param_type.is_a?(Symbol) && !GameData.const_defined?(param_type)
+              f.write(getConstantName(param_type, evo[2]))
+            elsif !param_type.nil?
+              f.write(evo[2].to_s)
             end
           end
           f.write("\r\n")
@@ -438,12 +436,10 @@ module Compiler
             evo_type_data = GameData::Evolution.get(evo[1])
             param_type = evo_type_data.parameter
             f.write(sprintf("%s,%s,", evo[0], evo_type_data.id.to_s))
-            if !param_type.nil?
-              if param_type.is_a?(Symbol) && !GameData.const_defined?(param_type)
-                f.write(getConstantName(param_type, evo[2]))
-              else
-                f.write(evo[2].to_s)
-              end
+            if param_type.is_a?(Symbol) && !GameData.const_defined?(param_type)
+              f.write(getConstantName(param_type, evo[2]))
+            elsif !param_type.nil?
+              f.write(evo[2].to_s)
             end
           end
           f.write("\r\n")

--- a/Data/Scripts/021_Compiler/004_Compiler_MapsAndEvents.rb
+++ b/Data/Scripts/021_Compiler/004_Compiler_MapsAndEvents.rb
@@ -551,7 +551,7 @@ module Compiler
     trainerChecker.pbTrainerBattleCheck(trtype, trname, battleid)
     # Set the event's charset to one depending on the trainer type if the event
     # doesn't have a charset
-    if firstpage.graphic.character_name == "" && GameData::TrainerType.exists?(trtype)
+    if firstpage.graphic.character_name.empty? && GameData::TrainerType.exists?(trtype)
       trainerid = GameData::TrainerType.get(trtype).id
       filename = GameData::TrainerType.charset_filename_brief(trainerid)
       if FileTest.image_exist?("Graphics/Characters/" + filename)
@@ -762,7 +762,7 @@ module Compiler
     lastPage = event.pages[event.pages.length - 1]
     if event.pages.length >= 2 &&
        lastPage.condition.switch1_valid &&
-       lastPage.graphic.character_name != "" &&
+       !lastPage.graphic.character_name.empty? &&
        lastPage.list.length > 5 &&
        lastPage.list[0].code == 111
       # This bit of code is just in case Switch 22 has been renamed/repurposed,
@@ -858,7 +858,7 @@ module Compiler
   def likely_passage?(thisEvent, mapID, mapData)
     return false if !thisEvent || thisEvent.pages.length == 0
     return false if thisEvent.pages.length != 1
-    if thisEvent.pages[0].graphic.character_name == "" &&
+    if thisEvent.pages[0].graphic.character_name.empty? &&
        thisEvent.pages[0].list.length <= 12 &&
        thisEvent.pages[0].list.any? { |cmd| cmd.code == 201 } &&   # Transfer Player
 #       mapData.isPassable?(mapID,thisEvent.x,thisEvent.y+1) &&
@@ -1390,12 +1390,12 @@ module Compiler
     return true if event.pages[0].list.length <= 1
     # pbPokemonMart events
     return true if event.pages[0].list.length <= 12 &&
-                   event.pages[0].graphic.character_name != "" &&   # Has charset
+                   !event.pages[0].graphic.character_name.empty? &&   # Has charset
                    event.pages[0].list[0].code == 355 &&   # First line is Script
                    event.pages[0].list[0].parameters[0][/^pbPokemonMart/]
     # pbSetPokemonCenter events
     return true if event.pages[0].list.length > 8 &&
-                   event.pages[0].graphic.character_name != "" &&   # Has charset
+                   !event.pages[0].graphic.character_name.empty? &&   # Has charset
                    event.pages[0].list[0].code == 355 &&   # First line is Script
                    event.pages[0].list[0].parameters[0][/^pbSetPokemonCenter/]
     return false
@@ -1412,8 +1412,8 @@ module Compiler
     # and a spot where the player can be
     yonderX = otherEvent.x + (otherEvent.x - thisEvent.x)
     yonderY = otherEvent.y + (otherEvent.y - thisEvent.y)
-    return thisEvent.pages[0].graphic.character_name != "" &&    # Has charset
-           otherEvent.pages[0].graphic.character_name == "" &&   # Has no charset
+    return !thisEvent.pages[0].graphic.character_name.empty? &&    # Has charset
+           otherEvent.pages[0].graphic.character_name.empty? &&   # Has no charset
            otherEvent.pages[0].trigger == 0 &&                   # Action trigger
            mapData.isPassable?(mapID, thisEvent.x, thisEvent.y) &&
            !mapData.isPassable?(mapID, otherEvent.x, otherEvent.y) &&

--- a/Data/Scripts/021_Compiler/004_Compiler_MapsAndEvents.rb
+++ b/Data/Scripts/021_Compiler/004_Compiler_MapsAndEvents.rb
@@ -156,7 +156,7 @@ module Compiler
       textsplit2 = t.split(/\n/)
       textsplit2.length.times do |i|
         textchunk = textsplit2[i].gsub(/\s+$/, "")
-        if textchunk && textchunk != ""
+        if !nil_or_empty?(textchunk)
           list.push(RPG::EventCommand.new((first) ? 101 : 401, indent, [textchunk]))
           first = false
         end
@@ -170,7 +170,7 @@ module Compiler
     textsplit2 = script.split(/\n/)
     textsplit2.length.times do |i|
       textchunk = textsplit2[i].gsub(/\s+$/, "")
-      if textchunk && textchunk != ""
+      if !nil_or_empty?(textchunk)
         list.push(RPG::EventCommand.new((first) ? 355 : 655, indent, [textchunk]))
         first = false
       end
@@ -398,7 +398,7 @@ module Compiler
       return @registeredSwitches[switch] if @registeredSwitches[switch]
       (1..5000).each do |id|
         name = @system.switches[id]
-        next if name && name != "" && name != switch
+        next if !nil_or_empty?(name) && name != switch
         @system.switches[id] = switch
         @registeredSwitches[switch] = id
         return id


### PR DESCRIPTION
This PR updates the checks for `nil` and empty strings from direct checks to method-based checks.
- Replaced `== nil` and `!= nil` with `.nil?`
- Replaced `x && x != ""` with `nil_or_empty?(x)`
- Replaced ` == ""` and `!= ""` with `empty?`
- Added method `empty?` for NilClass which always returns true. 