### PR TITLE
Add new flags for various species

### DIFF
--- a/PBS/Gen 5/pokemon.txt
+++ b/PBS/Gen 5/pokemon.txt
@@ -25,6 +25,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun's rays, the seed grows progressively larger.
 Generation = 1
+Flags = Starter
 Evolutions = IVYSAUR,Level,16
 #-------------------------------
 [IVYSAUR]
@@ -51,6 +52,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = To support its bulb, Ivysaur's legs grow sturdy. If it spends more time lying in the sunlight, the bud will soon bloom into a large flower.
 Generation = 1
+Flags = Starter
 Evolutions = VENUSAUR,Level,32
 #-------------------------------
 [VENUSAUR]
@@ -77,6 +79,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Venusaur's flower is said to take on vivid colors if it gets plenty of nutrition and sunlight. The flower's aroma soothes the emotions of people.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CHARMANDER]
 Name = Charmander
@@ -103,6 +106,7 @@ Habitat = Mountain
 Category = Lizard
 Pokedex = The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is happy, and blazes when it is enraged.
 Generation = 1
+Flags = Starter
 Evolutions = CHARMELEON,Level,16
 #-------------------------------
 [CHARMELEON]
@@ -129,6 +133,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = Without pity, its sharp claws destroy foes. If it encounters a strong enemy, it becomes agitated, and the flame on its tail flares with a bluish white color.
 Generation = 1
+Flags = Starter
 Evolutions = CHARIZARD,Level,36
 #-------------------------------
 [CHARIZARD]
@@ -155,6 +160,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = A Charizard flies about in search of strong opponents. It breathes intense flames that can melt any material. However, it will never torch a weaker foe.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [SQUIRTLE]
 Name = Squirtle
@@ -181,6 +187,7 @@ Habitat = WatersEdge
 Category = Tiny Turtle
 Pokedex = Its shell is not just for protection. Its rounded shape and the grooves on its surface minimize resistance in water, enabling Squirtle to swim at high speeds.
 Generation = 1
+Flags = Starter
 Evolutions = WARTORTLE,Level,16
 #-------------------------------
 [WARTORTLE]
@@ -207,6 +214,7 @@ Habitat = WatersEdge
 Category = Turtle
 Pokedex = Its large tail is covered with rich, thick fur that deepens in color with age. The scratches on its shell are evidence of this Pokémon's toughness in battle.
 Generation = 1
+Flags = Starter
 Evolutions = BLASTOISE,Level,36
 #-------------------------------
 [BLASTOISE]
@@ -233,6 +241,7 @@ Habitat = WatersEdge
 Category = Shellfish
 Pokedex = The waterspouts that protrude from its shell are highly accurate. Their bullets of water can precisely nail tin cans from a distance of over 160 feet.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CATERPIE]
 Name = Caterpie
@@ -4024,6 +4033,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = It waves its leaf around to keep foes at bay. However, a sweet fragrance also wafts from the leaf, creating a friendly atmosphere that becalms the battlers.
 Generation = 2
+Flags = Starter
 Evolutions = BAYLEEF,Level,16
 #-------------------------------
 [BAYLEEF]
@@ -4050,6 +4060,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = A Bayleef's neck is ringed by curled-up leaves. Inside each leaf is a small tree shoot. The fragrance of this shoot makes people peppy.
 Generation = 2
+Flags = Starter
 Evolutions = MEGANIUM,Level,32
 #-------------------------------
 [MEGANIUM]
@@ -4076,6 +4087,7 @@ Habitat = Grassland
 Category = Herb
 Pokedex = The fragrance of a Meganium's flower soothes and calms emotions. In battle, it gives off more of its becalming scent to blunt the foe's fighting spirit.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [CYNDAQUIL]
 Name = Cyndaquil
@@ -4102,6 +4114,7 @@ Habitat = Grassland
 Category = Fire Mouse
 Pokedex = It flares flames from its back to protect itself. The fire burns vigorously if the Pokémon is angry. When it is tired, it sputters with incomplete combustion.
 Generation = 2
+Flags = Starter
 Evolutions = QUILAVA,Level,14
 #-------------------------------
 [QUILAVA]
@@ -4128,6 +4141,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It intimidates foes with intense gusts of flames and superheated air. Its quick nimbleness lets it dodge attacks even while scorching an enemy.
 Generation = 2
+Flags = Starter
 Evolutions = TYPHLOSION,Level,36
 #-------------------------------
 [TYPHLOSION]
@@ -4154,6 +4168,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It can hide behind a shimmering heat haze that it creates using its intense flames. Typhlosion create blazing explosive blasts that burn everything to cinders.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [TOTODILE]
 Name = Totodile
@@ -4180,6 +4195,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Despite its small body, Totodile's jaws are very powerful. While it may think it is just playfully nipping, its bite has enough strength to cause serious injury.
 Generation = 2
+Flags = Starter
 Evolutions = CROCONAW,Level,18
 #-------------------------------
 [CROCONAW]
@@ -4206,6 +4222,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Once its jaws clamp down on its foe, it will absolutely not let go. Because the tips of its fangs are forked back like fishhooks, they become irremovably embedded.
 Generation = 2
+Flags = Starter
 Evolutions = FERALIGATR,Level,30
 #-------------------------------
 [FERALIGATR]
@@ -4232,6 +4249,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = It opens its huge mouth to intimidate enemies. In battle, it runs using its thick and powerful hind legs to charge the foe with incredible speed.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [SENTRET]
 Name = Sentret
@@ -6655,6 +6673,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = It makes its nest in a giant tree in the forest. It ferociously guards against anything nearing its territory. It is said to be the protector of the trees.
 Generation = 3
+Flags = Starter
 Evolutions = GROVYLE,Level,16
 #-------------------------------
 [GROVYLE]
@@ -6681,6 +6700,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = Leaves grow out of this Pokémon's body. They help obscure a Grovyle from the eyes of its enemies while it is in a thickly overgrown forest.
 Generation = 3
+Flags = Starter
 Evolutions = SCEPTILE,Level,36
 #-------------------------------
 [SCEPTILE]
@@ -6707,6 +6727,7 @@ Habitat = Forest
 Category = Forest
 Pokedex = In the jungle, its power is without equal. This Pokémon carefully grows trees and plants. It regulates its body temperature by basking in sunlight.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [TORCHIC]
 Name = Torchic
@@ -6733,6 +6754,7 @@ Habitat = Grassland
 Category = Chick
 Pokedex = If attacked, it strikes back by spitting balls of fire it forms in its stomach. A Torchic dislikes darkness because it can't see its surroundings.
 Generation = 3
+Flags = Starter
 Evolutions = COMBUSKEN,Level,16
 #-------------------------------
 [COMBUSKEN]
@@ -6759,6 +6781,7 @@ Habitat = Grassland
 Category = Young Fowl
 Pokedex = It lashes out with 10 kicks per second. Its strong fighting instinct compels it to keep up its offensive until the opponent gives up.
 Generation = 3
+Flags = Starter
 Evolutions = BLAZIKEN,Level,36
 #-------------------------------
 [BLAZIKEN]
@@ -6785,6 +6808,7 @@ Habitat = Grassland
 Category = Blaze
 Pokedex = It learns martial arts that use punches and kicks. Every several years, its old feathers burn off, and new, supple feathers grow back in their place.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [MUDKIP]
 Name = Mudkip
@@ -6811,6 +6835,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = On land, it can powerfully lift large boulders by planting its four feet and heaving. It sleeps by burying itself in soil at the water's edge.
 Generation = 3
+Flags = Starter
 Evolutions = MARSHTOMP,Level,16
 #-------------------------------
 [MARSHTOMP]
@@ -6837,6 +6862,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = Its toughened hind legs enable it to stand upright. Because it weakens if its skin dries out, it replenishes fluids by playing in mud.
 Generation = 3
+Flags = Starter
 Evolutions = SWAMPERT,Level,36
 #-------------------------------
 [SWAMPERT]
@@ -6863,6 +6889,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = If it senses the approach of a storm and a tidal wave, it protects its seaside nest by piling up boulders. It swims as fast as a jet ski.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [POOCHYENA]
 Name = Poochyena
@@ -10202,6 +10229,7 @@ Shape = Quadruped
 Category = Tiny Leaf
 Pokedex = Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.
 Generation = 4
+Flags = Starter
 Evolutions = GROTLE,Level,18
 #-------------------------------
 [GROTLE]
@@ -10227,6 +10255,7 @@ Shape = Quadruped
 Category = Grove
 Pokedex = It lives along water in forests. In the daytime, it leaves the forest to sunbathe its treed shell.
 Generation = 4
+Flags = Starter
 Evolutions = TORTERRA,Level,32
 #-------------------------------
 [TORTERRA]
@@ -10252,6 +10281,7 @@ Shape = Quadruped
 Category = Continent
 Pokedex = Small Pokémon occasionally gather on its unmoving back to begin building their nests.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [CHIMCHAR]
 Name = Chimchar
@@ -10277,6 +10307,7 @@ Shape = BipedalTail
 Category = Chimp
 Pokedex = It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps.
 Generation = 4
+Flags = Starter
 Evolutions = MONFERNO,Level,14
 #-------------------------------
 [MONFERNO]
@@ -10302,6 +10333,7 @@ Shape = BipedalTail
 Category = Playful
 Pokedex = To intimidate attackers, it stretches the fire on its tail to make itself appear bigger.
 Generation = 4
+Flags = Starter
 Evolutions = INFERNAPE,Level,36
 #-------------------------------
 [INFERNAPE]
@@ -10327,6 +10359,7 @@ Shape = BipedalTail
 Category = Flame
 Pokedex = It uses a special kind of martial arts involving all its limbs. Its fire never goes out.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [PIPLUP]
 Name = Piplup
@@ -10352,6 +10385,7 @@ Shape = Bipedal
 Category = Penguin
 Pokedex = Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.
 Generation = 4
+Flags = Starter
 Evolutions = PRINPLUP,Level,16
 #-------------------------------
 [PRINPLUP]
@@ -10377,6 +10411,7 @@ Shape = BipedalTail
 Category = Penguin
 Pokedex = It lives alone, away from others. Apparently, every one of them believes it is the most important.
 Generation = 4
+Flags = Starter
 Evolutions = EMPOLEON,Level,36
 #-------------------------------
 [EMPOLEON]
@@ -10402,6 +10437,7 @@ Shape = BipedalTail
 Category = Emperor
 Pokedex = The three horns that extend from its beak attest to its power. The leader has the biggest horns.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [STARLY]
 Name = Starly
@@ -12927,6 +12963,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They photosynthesize by bathing their tails in sunlight. When they are not feeling well, their tails droop.
 Generation = 5
+Flags = Starter
 Evolutions = SERVINE,Level,17
 #-------------------------------
 [SERVINE]
@@ -12952,6 +12989,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.
 Generation = 5
+Flags = Starter
 Evolutions = SERPERIOR,Level,36
 #-------------------------------
 [SERPERIOR]
@@ -12977,6 +13015,7 @@ Shape = Serpentine
 Category = Regal
 Pokedex = They raise their heads to intimidate opponents, but only give it their all when fighting a powerful opponent.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [TEPIG]
 Name = Tepig
@@ -13002,6 +13041,7 @@ Shape = Quadruped
 Category = Fire Pig
 Pokedex = It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.
 Generation = 5
+Flags = Starter
 Evolutions = PIGNITE,Level,17
 #-------------------------------
 [PIGNITE]
@@ -13027,6 +13067,7 @@ Shape = BipedalTail
 Category = Fire Pig
 Pokedex = Whatever it eats becomes fuel for the flame in its stomach. When it is angered, the intensity of the flame increases.
 Generation = 5
+Flags = Starter
 Evolutions = EMBOAR,Level,36
 #-------------------------------
 [EMBOAR]
@@ -13052,6 +13093,7 @@ Shape = BipedalTail
 Category = Mega Fire Pig
 Pokedex = It can throw a fire punch by setting its fists on fire with its fiery chin. It cares deeply about its friends.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [OSHAWOTT]
 Name = Oshawott
@@ -13077,6 +13119,7 @@ Shape = BipedalTail
 Category = Sea Otter
 Pokedex = The scalchop on its stomach is made from the same elements as claws. It detaches the scalchop for use as a blade.
 Generation = 5
+Flags = Starter
 Evolutions = DEWOTT,Level,17
 #-------------------------------
 [DEWOTT]
@@ -13102,6 +13145,7 @@ Shape = BipedalTail
 Category = Discipline
 Pokedex = Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.
 Generation = 5
+Flags = Starter
 Evolutions = SAMUROTT,Level,36
 #-------------------------------
 [SAMUROTT]
@@ -13127,6 +13171,7 @@ Shape = Quadruped
 Category = Formidable
 Pokedex = Part of the armor on its anterior legs becomes a giant sword. Its cry alone is enough to intimidate most enemies.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [PATRAT]
 Name = Patrat

--- a/PBS/Gen 5/pokemon.txt
+++ b/PBS/Gen 5/pokemon.txt
@@ -4008,6 +4008,7 @@ Habitat = Rare
 Category = New Species
 Pokedex = A Mew is said to possess the genes of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.
 Generation = 1
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -6653,6 +6654,7 @@ Habitat = Forest
 Category = Time Travel
 Pokedex = This Pokémon came from the future by crossing over time. It is thought that so long as Celebi appears, a bright and shining future awaits us.
 Generation = 2
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -10193,6 +10195,7 @@ Habitat = Mountain
 Category = Wish
 Pokedex = Jirachi is said to make wishes come true. While it sleeps, a tough crystalline shell envelops the body to protect it from enemies.
 Generation = 3
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -10221,6 +10224,7 @@ Category = DNA
 Pokedex = A Pokémon that mutated from an extraterrestrial virus exposed to a laser beam. Its body is configured for superior agility and speed.
 FormName = Normal Forme
 Generation = 3
+Flags = Mythical
 #-------------------------------
 [TURTWIG]
 Name = Turtwig
@@ -12843,6 +12847,7 @@ Shape = HeadArms
 Category = Sea Drifter
 Pokedex = A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [MANAPHY]
 Name = Manaphy
@@ -12867,6 +12872,7 @@ Shape = Bipedal
 Category = Seafaring
 Pokedex = Born on a cold seafloor, it will swim great distances to return to its birthplace.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [DARKRAI]
 Name = Darkrai
@@ -12890,6 +12896,7 @@ Shape = Bipedal
 Category = Pitch-Black
 Pokedex = It can lull people to sleep and make them dream. It is active during nights of the new moon.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [SHAYMIN]
 Name = Shaymin
@@ -12914,6 +12921,7 @@ Category = Gratitude
 Pokedex = It lives in flower patches and avoids detection by curling up to look like a flowering plant.
 FormName = Land Forme
 Generation = 4
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -12941,6 +12949,7 @@ Category = Alpha
 Pokedex = It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.
 FormName = Normal Type
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [VICTINI]
 Name = Victini
@@ -12964,6 +12973,7 @@ Shape = Bipedal
 Category = Victory
 Pokedex = This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [SNIVY]
 Name = Snivy
@@ -16862,6 +16872,7 @@ Category = Colt
 Pokedex = It crosses the world, running over the surfaces of oceans and rivers. It appears at scenic waterfronts.
 FormName = Ordinary Form
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [MELOETTA]
 Name = Meloetta
@@ -16886,6 +16897,7 @@ Category = Melody
 Pokedex = Many famous songs have been inspired by the melodies that Meloetta plays.
 FormName = Aria Forme
 Generation = 5
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -16913,3 +16925,4 @@ Category = Paleozoic
 Pokedex = This ancient bug Pokémon was altered by Team Plasma. They upgraded the cannon on its back.
 FormName = Normal
 Generation = 5
+Flags = Mythical

--- a/PBS/Gen 5/pokemon.txt
+++ b/PBS/Gen 5/pokemon.txt
@@ -3824,6 +3824,7 @@ Habitat = Rare
 Category = Freeze
 Pokedex = Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [ZAPDOS]
 Name = Zapdos
@@ -3849,6 +3850,7 @@ Habitat = Rare
 Category = Electric
 Pokedex = Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. It gains power if it is stricken by lightning bolts.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MOLTRES]
 Name = Moltres
@@ -3874,6 +3876,7 @@ Habitat = Rare
 Category = Flame
 Pokedex = Moltres is a legendary bird Pokémon that can control fire. If injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [DRATINI]
 Name = Dratini
@@ -3980,6 +3983,7 @@ Habitat = Rare
 Category = Genetic
 Pokedex = A Pokémon that was created by genetic manipulation. However, even though the scientific power of humans made its body, they failed to give it a warm heart.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MEW]
 Name = Mew
@@ -6440,6 +6444,7 @@ Habitat = Grassland
 Category = Thunder
 Pokedex = Raikou embodies the speed of lightning. Its roars send shock waves shuddering through the air and ground as if lightning bolts were crashing down.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [ENTEI]
 Name = Entei
@@ -6465,6 +6470,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = Entei embodies the passion of magma. It is thought to have been born in the eruption of a volcano. It blasts fire that consumes all that it touches.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [SUICUNE]
 Name = Suicune
@@ -6490,6 +6496,7 @@ Habitat = Grassland
 Category = Aurora
 Pokedex = Suicune embodies the compassion of a pure spring of water. It runs across the land with gliding elegance. It has the power to purify dirty water.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [LARVITAR]
 Name = Larvitar
@@ -6592,6 +6599,7 @@ Habitat = Rare
 Category = Diving
 Pokedex = Lugia is so powerful even a light fluttering of its wings can blow apart houses. As a result, it chooses to live out of sight deep under the sea.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [HOOH]
 Name = Ho-Oh
@@ -6617,6 +6625,7 @@ Habitat = Rare
 Category = Rainbow
 Pokedex = Its feathers--which glow in seven colors depending on the angle at which light strikes them--are thought to bring joy. It is said to live at the foot of a rainbow.
 Generation = 2
+Flags = Legendary
 WildItemCommon = SACREDASH
 WildItemUncommon = SACREDASH
 WildItemRare = SACREDASH
@@ -9982,6 +9991,7 @@ Habitat = Cave
 Category = Rock Peak
 Pokedex = A Pokémon that is made entirely of rocks and boulders. If parts of its body chip off in battle, Regirock repairs itself by adding new rocks.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGICE]
 Name = Regice
@@ -10007,6 +10017,7 @@ Habitat = Cave
 Category = Iceberg
 Pokedex = Its entire body is made of Antarctic ice. After extensive studies, researchers believe the ice was formed during an ice age.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGISTEEL]
 Name = Registeel
@@ -10032,6 +10043,7 @@ Habitat = Cave
 Category = Iron
 Pokedex = Its body is harder than any other kind of metal. The body metal is composed of a mysterious substance. Not only is it hard, it shrinks and stretches flexibly.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIAS]
 Name = Latias
@@ -10056,6 +10068,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = They make a small herd of only several members. They rarely make contact with people or other Pokémon. They disappear if they sense enemies.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIOS]
 Name = Latios
@@ -10080,6 +10093,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = Even in hiding, it can detect the locations of others and sense their emotions since it has telepathy. Its intelligence allows it to understand human languages.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [KYOGRE]
 Name = Kyogre
@@ -10104,6 +10118,7 @@ Habitat = Sea
 Category = Sea Basin
 Pokedex = Kyogre has appeared in mythology as the creator of the sea. After long years of feuding with Groudon, it took to sleep at the bottom of the sea.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [GROUDON]
 Name = Groudon
@@ -10128,6 +10143,7 @@ Habitat = RoughTerrain
 Category = Continent
 Pokedex = Groudon has appeared in mythology as the creator of the land. It sleeps in magma underground and is said to make volcanoes erupt on awakening.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [RAYQUAZA]
 Name = Rayquaza
@@ -10152,6 +10168,7 @@ Habitat = Rare
 Category = Sky High
 Pokedex = A Pokémon that flies endlessly in the ozone layer. It is said it would descend to the ground if Kyogre and Groudon were to fight.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [JIRACHI]
 Name = Jirachi
@@ -12605,6 +12622,7 @@ Shape = BipedalTail
 Category = Knowledge
 Pokedex = Known as "The Being of Knowledge." It is said that it can wipe out the memory of those who see its eyes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [MESPRIT]
 Name = Mesprit
@@ -12628,6 +12646,7 @@ Shape = BipedalTail
 Category = Emotion
 Pokedex = Known as "The Being of Emotion." It taught humans the nobility of sorrow, pain, and joy.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [AZELF]
 Name = Azelf
@@ -12651,6 +12670,7 @@ Shape = BipedalTail
 Category = Willpower
 Pokedex = Known as "The Being of Willpower." It sleeps at the bottom of a lake to keep the world in balance.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [DIALGA]
 Name = Dialga
@@ -12675,6 +12695,7 @@ Shape = Quadruped
 Category = Temporal
 Pokedex = It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PALKIA]
 Name = Palkia
@@ -12699,6 +12720,7 @@ Shape = BipedalTail
 Category = Spatial
 Pokedex = It has the ability to distort space. It is described as a deity in Sinnoh-region mythology.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [HEATRAN]
 Name = Heatran
@@ -12723,6 +12745,7 @@ Shape = Quadruped
 Category = Lava Dome
 Pokedex = It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [REGIGIGAS]
 Name = Regigigas
@@ -12746,6 +12769,7 @@ Shape = Bipedal
 Category = Colossal
 Pokedex = There is an enduring legend that states this Pokémon towed continents with ropes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [GIRATINA]
 Name = Giratina
@@ -12771,6 +12795,7 @@ Category = Renegade
 Pokedex = A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery.
 FormName = Altered Forme
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [CRESSELIA]
 Name = Cresselia
@@ -12794,6 +12819,7 @@ Shape = Serpentine
 Category = Lunar
 Pokedex = Shiny particles are released from its wings like a veil. It is said to represent the crescent moon.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PHIONE]
 Name = Phione
@@ -16613,6 +16639,7 @@ Shape = Quadruped
 Category = Iron Will
 Pokedex = It has a body and heart of steel. Its glare is sufficient to make even an unruly Pokémon obey it.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TERRAKION]
 Name = Terrakion
@@ -16636,6 +16663,7 @@ Shape = Quadruped
 Category = Cavern
 Pokedex = Its charge is strong enough to break through a giant castle wall in one blow. This Pokémon is spoken of in legends.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [VIRIZION]
 Name = Virizion
@@ -16659,6 +16687,7 @@ Shape = Quadruped
 Category = Grassland
 Pokedex = Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TORNADUS]
 Name = Tornadus
@@ -16684,6 +16713,7 @@ Category = Cyclone
 Pokedex = Tornadus expels massive energy from its tail, causing severe storms. Its power is great enough to blow houses away.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [THUNDURUS]
 Name = Thundurus
@@ -16709,6 +16739,7 @@ Category = Bolt Strike
 Pokedex = The spikes on its tail discharge immense bolts of lightning. It flies around the Unova region firing off lightning bolts.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [RESHIRAM]
 Name = Reshiram
@@ -16732,6 +16763,7 @@ Shape = Winged
 Category = Vast White
 Pokedex = When Reshiram's tail flares, the heat energy moves the atmosphere and changes the world's weather.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [ZEKROM]
 Name = Zekrom
@@ -16755,6 +16787,7 @@ Shape = BipedalTail
 Category = Deep Black
 Pokedex = This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [LANDORUS]
 Name = Landorus
@@ -16780,6 +16813,7 @@ Category = Abundance
 Pokedex = The energy that comes pouring from its tail increases the nutrition in the soil, making crops grow to great size.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KYUREM]
 Name = Kyurem
@@ -16803,6 +16837,7 @@ Shape = BipedalTail
 Category = Boundary
 Pokedex = It generates a powerful, freezing energy inside itself, but its body became frozen when the energy leaked out.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KELDEO]
 Name = Keldeo

--- a/PBS/Gen 7/pokemon.txt
+++ b/PBS/Gen 7/pokemon.txt
@@ -3816,6 +3816,7 @@ Habitat = Rare
 Category = Freeze
 Pokedex = Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [ZAPDOS]
 Name = Zapdos
@@ -3841,6 +3842,7 @@ Habitat = Rare
 Category = Electric
 Pokedex = Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. It gains power if it is stricken by lightning bolts.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MOLTRES]
 Name = Moltres
@@ -3866,6 +3868,7 @@ Habitat = Rare
 Category = Flame
 Pokedex = Moltres is a legendary bird Pokémon that can control fire. If injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [DRATINI]
 Name = Dratini
@@ -3972,6 +3975,7 @@ Habitat = Rare
 Category = Genetic
 Pokedex = A Pokémon that was created by genetic manipulation. However, even though the scientific power of humans made its body, they failed to give it a warm heart.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MEW]
 Name = Mew
@@ -6422,6 +6426,7 @@ Habitat = Grassland
 Category = Thunder
 Pokedex = Raikou embodies the speed of lightning. Its roars send shock waves shuddering through the air and ground as if lightning bolts were crashing down.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [ENTEI]
 Name = Entei
@@ -6447,6 +6452,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = Entei embodies the passion of magma. It is thought to have been born in the eruption of a volcano. It blasts fire that consumes all that it touches.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [SUICUNE]
 Name = Suicune
@@ -6472,6 +6478,7 @@ Habitat = Grassland
 Category = Aurora
 Pokedex = Suicune embodies the compassion of a pure spring of water. It runs across the land with gliding elegance. It has the power to purify dirty water.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [LARVITAR]
 Name = Larvitar
@@ -6574,6 +6581,7 @@ Habitat = Rare
 Category = Diving
 Pokedex = Lugia is so powerful even a light fluttering of its wings can blow apart houses. As a result, it chooses to live out of sight deep under the sea.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [HOOH]
 Name = Ho-Oh
@@ -6599,6 +6607,7 @@ Habitat = Rare
 Category = Rainbow
 Pokedex = Its feathers--which glow in seven colors depending on the angle at which light strikes them--are thought to bring joy. It is said to live at the foot of a rainbow.
 Generation = 2
+Flags = Legendary
 WildItemCommon = SACREDASH
 WildItemUncommon = SACREDASH
 WildItemRare = SACREDASH
@@ -9977,6 +9986,7 @@ Habitat = Cave
 Category = Rock Peak
 Pokedex = A Pokémon that is made entirely of rocks and boulders. If parts of its body chip off in battle, Regirock repairs itself by adding new rocks.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGICE]
 Name = Regice
@@ -10002,6 +10012,7 @@ Habitat = Cave
 Category = Iceberg
 Pokedex = Its entire body is made of Antarctic ice. After extensive studies, researchers believe the ice was formed during an ice age.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGISTEEL]
 Name = Registeel
@@ -10027,6 +10038,7 @@ Habitat = Cave
 Category = Iron
 Pokedex = Its body is harder than any other kind of metal. The body metal is composed of a mysterious substance. Not only is it hard, it shrinks and stretches flexibly.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIAS]
 Name = Latias
@@ -10051,6 +10063,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = They make a small herd of only several members. They rarely make contact with people or other Pokémon. They disappear if they sense enemies.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIOS]
 Name = Latios
@@ -10075,6 +10088,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = Even in hiding, it can detect the locations of others and sense their emotions since it has telepathy. Its intelligence allows it to understand human languages.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [KYOGRE]
 Name = Kyogre
@@ -10099,6 +10113,7 @@ Habitat = Sea
 Category = Sea Basin
 Pokedex = Kyogre has appeared in mythology as the creator of the sea. After long years of feuding with Groudon, it took to sleep at the bottom of the sea.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [GROUDON]
 Name = Groudon
@@ -10123,6 +10138,7 @@ Habitat = RoughTerrain
 Category = Continent
 Pokedex = Groudon has appeared in mythology as the creator of the land. It sleeps in magma underground and is said to make volcanoes erupt on awakening.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [RAYQUAZA]
 Name = Rayquaza
@@ -10147,6 +10163,7 @@ Habitat = Rare
 Category = Sky High
 Pokedex = A Pokémon that flies endlessly in the ozone layer. It is said it would descend to the ground if Kyogre and Groudon were to fight.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [JIRACHI]
 Name = Jirachi
@@ -12578,6 +12595,7 @@ Shape = BipedalTail
 Category = Knowledge
 Pokedex = Known as "The Being of Knowledge." It is said that it can wipe out the memory of those who see its eyes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [MESPRIT]
 Name = Mesprit
@@ -12601,6 +12619,7 @@ Shape = BipedalTail
 Category = Emotion
 Pokedex = Known as "The Being of Emotion." It taught humans the nobility of sorrow, pain, and joy.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [AZELF]
 Name = Azelf
@@ -12624,6 +12643,7 @@ Shape = BipedalTail
 Category = Willpower
 Pokedex = Known as "The Being of Willpower." It sleeps at the bottom of a lake to keep the world in balance.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [DIALGA]
 Name = Dialga
@@ -12648,6 +12668,7 @@ Shape = Quadruped
 Category = Temporal
 Pokedex = It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PALKIA]
 Name = Palkia
@@ -12672,6 +12693,7 @@ Shape = BipedalTail
 Category = Spatial
 Pokedex = It has the ability to distort space. It is described as a deity in Sinnoh-region mythology.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [HEATRAN]
 Name = Heatran
@@ -12696,6 +12718,7 @@ Shape = Quadruped
 Category = Lava Dome
 Pokedex = It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [REGIGIGAS]
 Name = Regigigas
@@ -12719,6 +12742,7 @@ Shape = Bipedal
 Category = Colossal
 Pokedex = There is an enduring legend that states this Pokémon towed continents with ropes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [GIRATINA]
 Name = Giratina
@@ -12744,6 +12768,7 @@ Category = Renegade
 Pokedex = A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery.
 FormName = Altered Forme
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [CRESSELIA]
 Name = Cresselia
@@ -12767,6 +12792,7 @@ Shape = Serpentine
 Category = Lunar
 Pokedex = Shiny particles are released from its wings like a veil. It is said to represent the crescent moon.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PHIONE]
 Name = Phione
@@ -16553,6 +16579,7 @@ Shape = Quadruped
 Category = Iron Will
 Pokedex = It has a body and heart of steel. Its glare is sufficient to make even an unruly Pokémon obey it.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TERRAKION]
 Name = Terrakion
@@ -16576,6 +16603,7 @@ Shape = Quadruped
 Category = Cavern
 Pokedex = Its charge is strong enough to break through a giant castle wall in one blow. This Pokémon is spoken of in legends.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [VIRIZION]
 Name = Virizion
@@ -16599,6 +16627,7 @@ Shape = Quadruped
 Category = Grassland
 Pokedex = Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TORNADUS]
 Name = Tornadus
@@ -16624,6 +16653,7 @@ Category = Cyclone
 Pokedex = Tornadus expels massive energy from its tail, causing severe storms. Its power is great enough to blow houses away.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [THUNDURUS]
 Name = Thundurus
@@ -16649,6 +16679,7 @@ Category = Bolt Strike
 Pokedex = The spikes on its tail discharge immense bolts of lightning. It flies around the Unova region firing off lightning bolts.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [RESHIRAM]
 Name = Reshiram
@@ -16672,6 +16703,7 @@ Shape = Winged
 Category = Vast White
 Pokedex = When Reshiram's tail flares, the heat energy moves the atmosphere and changes the world's weather.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [ZEKROM]
 Name = Zekrom
@@ -16695,6 +16727,7 @@ Shape = BipedalTail
 Category = Deep Black
 Pokedex = This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [LANDORUS]
 Name = Landorus
@@ -16720,6 +16753,7 @@ Category = Abundance
 Pokedex = The energy that comes pouring from its tail increases the nutrition in the soil, making crops grow to great size.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KYUREM]
 Name = Kyurem
@@ -16743,6 +16777,7 @@ Shape = BipedalTail
 Category = Boundary
 Pokedex = It generates a powerful, freezing energy inside itself, but its body became frozen when the energy leaked out.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KELDEO]
 Name = Keldeo
@@ -18510,6 +18545,7 @@ Category = Life
 Pokedex = Legends say it can share eternal life. It slept for a thousand years in the form of a tree before its revival.
 FormName = Neutral Mode
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [YVELTAL]
 Name = Yveltal
@@ -18533,6 +18569,7 @@ Shape = Winged
 Category = Destruction
 Pokedex = When its life comes to an end, it absorbs the life energy of every living thing and turns into a cocoon once more.
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [ZYGARDE]
 Name = Zygarde
@@ -18557,6 +18594,7 @@ Category = Order
 Pokedex = It's thought to be monitoring the ecosystem. There are rumors that even greater power lies hidden within it.
 FormName = 50% Forme
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [DIANCIE]
 Name = Diancie
@@ -19937,6 +19975,7 @@ Shape = Quadruped
 Category = Synthetic
 Pokedex = The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power.
 Generation = 7
+Flags = Legendary
 Evolutions = SILVALLY,Happiness,
 #-------------------------------
 [SILVALLY]
@@ -19962,6 +20001,7 @@ Category = Synthetic
 Pokedex = Its trust in its partner is what awakens it. This Pokémon is capable of changing its type, a flexibility that is well displayed in battle.
 FormName = Type: Normal
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [MINIOR]
 Name = Minior
@@ -20265,6 +20305,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = Although it's called a guardian deity, if a person or Pokémon puts it in a bad mood, it will become a malevolent deity and attack.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPULELE]
 Name = Tapu Lele
@@ -20289,6 +20330,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = As it flutters about, it scatters its strangely glowing scales. Touching them is said to restore good health on the spot.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPUBULU]
 Name = Tapu Bulu
@@ -20313,6 +20355,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = It pulls large trees up by the roots and swings them around. It causes vegetation to grow, and then it absorbs energy from the growth.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPUFINI]
 Name = Tapu Fini
@@ -20337,6 +20380,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = The dense fog it creates brings the downfall and destruction of its confused enemies. Ocean currents are the source of its energy.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [COSMOG]
 Name = Cosmog
@@ -20359,6 +20403,7 @@ Shape = Head
 Category = Nebula
 Pokedex = Whether or not it's a Pokémon from this world is a mystery. When it's in a jam, it warps away to a safe place to hide.
 Generation = 7
+Flags = Legendary
 Evolutions = COSMOEM,Level,43
 #-------------------------------
 [COSMOEM]
@@ -20382,6 +20427,7 @@ Shape = Head
 Category = Protostar
 Pokedex = Motionless as if dead, its body is faintly warm to the touch. In the distant past, it was called the cocoon of the stars.
 Generation = 7
+Flags = Legendary
 Evolutions = SOLGALEO,LevelDay,53,LUNALA,LevelNight,53
 #-------------------------------
 [SOLGALEO]
@@ -20406,6 +20452,7 @@ Shape = Quadruped
 Category = Sunne
 Pokedex = It is said to live in another world. The intense light it radiates from the surface of its body can make the darkest of nights light up like midday.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [LUNALA]
 Name = Lunala
@@ -20429,6 +20476,7 @@ Shape = Winged
 Category = Moone
 Pokedex = Said to live in another world, this Pokémon devours light, drawing the moonless dark veil of night over the brightness of day.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [NIHILEGO]
 Name = Nihilego
@@ -20620,6 +20668,7 @@ Shape = HeadArms
 Category = Prism
 Pokedex = Light is apparently the source of its energy. It has an extraordinarily vicious disposition and is constantly firing off laser beams.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [MAGEARNA]
 Name = Magearna

--- a/PBS/Gen 7/pokemon.txt
+++ b/PBS/Gen 7/pokemon.txt
@@ -4000,6 +4000,7 @@ Habitat = Rare
 Category = New Species
 Pokedex = A Mew is said to possess the genes of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.
 Generation = 1
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -6635,6 +6636,7 @@ Habitat = Forest
 Category = Time Travel
 Pokedex = This Pokémon came from the future by crossing over time. It is thought that so long as Celebi appears, a bright and shining future awaits us.
 Generation = 2
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -10188,6 +10190,7 @@ Habitat = Mountain
 Category = Wish
 Pokedex = Jirachi is said to make wishes come true. While it sleeps, a tough crystalline shell envelops the body to protect it from enemies.
 Generation = 3
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -10216,6 +10219,7 @@ Category = DNA
 Pokedex = A Pokémon that mutated from an extraterrestrial virus exposed to a laser beam. Its body is configured for superior agility and speed.
 FormName = Normal Forme
 Generation = 3
+Flags = Mythical
 #-------------------------------
 [TURTWIG]
 Name = Turtwig
@@ -12816,6 +12820,7 @@ Shape = HeadArms
 Category = Sea Drifter
 Pokedex = A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [MANAPHY]
 Name = Manaphy
@@ -12840,6 +12845,7 @@ Shape = Bipedal
 Category = Seafaring
 Pokedex = Born on a cold seafloor, it will swim great distances to return to its birthplace.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [DARKRAI]
 Name = Darkrai
@@ -12863,6 +12869,7 @@ Shape = Bipedal
 Category = Pitch-Black
 Pokedex = It can lull people to sleep and make them dream. It is active during nights of the new moon.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [SHAYMIN]
 Name = Shaymin
@@ -12887,6 +12894,7 @@ Category = Gratitude
 Pokedex = It lives in flower patches and avoids detection by curling up to look like a flowering plant.
 FormName = Land Forme
 Generation = 4
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -12914,6 +12922,7 @@ Category = Alpha
 Pokedex = It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.
 FormName = Normal Type
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [VICTINI]
 Name = Victini
@@ -12937,6 +12946,7 @@ Shape = Bipedal
 Category = Victory
 Pokedex = This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [SNIVY]
 Name = Snivy
@@ -16802,6 +16812,7 @@ Category = Colt
 Pokedex = It crosses the world, running over the surfaces of oceans and rivers. It appears at scenic waterfronts.
 FormName = Ordinary Form
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [MELOETTA]
 Name = Meloetta
@@ -16826,6 +16837,7 @@ Category = Melody
 Pokedex = Many famous songs have been inspired by the melodies that Meloetta plays.
 FormName = Aria Forme
 Generation = 5
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -16853,6 +16865,7 @@ Category = Paleozoic
 Pokedex = This ancient bug Pokémon was altered by Team Plasma. They upgraded the cannon on its back.
 FormName = Normal
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [CHESPIN]
 Name = Chespin
@@ -18618,6 +18631,7 @@ Shape = HeadArms
 Category = Jewel
 Pokedex = A sudden transformation of Carbink, its pink, glimmering body is said to be the loveliest sight in the whole world.
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [HOOPA]
 Name = Hoopa
@@ -18642,6 +18656,7 @@ Category = Mischief
 Pokedex = This troublemaker sends anything and everything to faraway places using its loop, which can warp space.
 FormName = Hoopa Confined
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [VOLCANION]
 Name = Volcanion
@@ -18665,6 +18680,7 @@ Shape = Quadruped
 Category = Steam
 Pokedex = It lets out billows of steam and disappears into the dense fog. It's said to live in mountains where humans do not tread.
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [ROWLET]
 Name = Rowlet
@@ -20692,6 +20708,7 @@ Shape = Bipedal
 Category = Artificial
 Pokedex = This artificial Pokémon, constructed more than 500 years ago, can understand human speech but cannot itself speak.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [MARSHADOW]
 Name = Marshadow
@@ -20715,6 +20732,7 @@ Shape = Bipedal
 Category = Gloomdweller
 Pokedex = Able to conceal itself in shadows, it never appears before humans, so its very existence was the stuff of myth.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [POIPOLE]
 Name = Poipole
@@ -20835,6 +20853,7 @@ Shape = Bipedal
 Category = Thunderclap
 Pokedex = It approaches its enemies at the speed of lightning, then tears them limb from limb with its sharp claws.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [MELTAN]
 Name = Meltan
@@ -20857,6 +20876,7 @@ Shape = Head
 Category = Hex Nut
 Pokedex = It melts particles of iron and other metals found in the subsoil, so it can absorb them into its body of molten steel.
 Generation = 7
+Flags = Mythical
 Evolutions = MELMETAL,None,
 #-------------------------------
 [MELMETAL]
@@ -20880,3 +20900,4 @@ Shape = Bipedal
 Category = Hex Nut
 Pokedex = Revered long ago for its capacity to create iron from nothing, for some reason it has come back to life after 3,000 years.
 Generation = 7
+Flags = Mythical

--- a/PBS/Gen 7/pokemon.txt
+++ b/PBS/Gen 7/pokemon.txt
@@ -25,6 +25,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun's rays, the seed grows progressively larger.
 Generation = 1
+Flags = Starter
 Evolutions = IVYSAUR,Level,16
 #-------------------------------
 [IVYSAUR]
@@ -51,6 +52,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = To support its bulb, Ivysaur's legs grow sturdy. If it spends more time lying in the sunlight, the bud will soon bloom into a large flower.
 Generation = 1
+Flags = Starter
 Evolutions = VENUSAUR,Level,32
 #-------------------------------
 [VENUSAUR]
@@ -77,6 +79,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Venusaur's flower is said to take on vivid colors if it gets plenty of nutrition and sunlight. The flower's aroma soothes the emotions of people.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CHARMANDER]
 Name = Charmander
@@ -103,6 +106,7 @@ Habitat = Mountain
 Category = Lizard
 Pokedex = The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is happy, and blazes when it is enraged.
 Generation = 1
+Flags = Starter
 Evolutions = CHARMELEON,Level,16
 #-------------------------------
 [CHARMELEON]
@@ -129,6 +133,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = Without pity, its sharp claws destroy foes. If it encounters a strong enemy, it becomes agitated, and the flame on its tail flares with a bluish white color.
 Generation = 1
+Flags = Starter
 Evolutions = CHARIZARD,Level,36
 #-------------------------------
 [CHARIZARD]
@@ -155,6 +160,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = A Charizard flies about in search of strong opponents. It breathes intense flames that can melt any material. However, it will never torch a weaker foe.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [SQUIRTLE]
 Name = Squirtle
@@ -181,6 +187,7 @@ Habitat = WatersEdge
 Category = Tiny Turtle
 Pokedex = Its shell is not just for protection. Its rounded shape and the grooves on its surface minimize resistance in water, enabling Squirtle to swim at high speeds.
 Generation = 1
+Flags = Starter
 Evolutions = WARTORTLE,Level,16
 #-------------------------------
 [WARTORTLE]
@@ -207,6 +214,7 @@ Habitat = WatersEdge
 Category = Turtle
 Pokedex = Its large tail is covered with rich, thick fur that deepens in color with age. The scratches on its shell are evidence of this Pokémon's toughness in battle.
 Generation = 1
+Flags = Starter
 Evolutions = BLASTOISE,Level,36
 #-------------------------------
 [BLASTOISE]
@@ -233,6 +241,7 @@ Habitat = WatersEdge
 Category = Shellfish
 Pokedex = The waterspouts that protrude from its shell are highly accurate. Their bullets of water can precisely nail tin cans from a distance of over 160 feet.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CATERPIE]
 Name = Caterpie
@@ -4016,6 +4025,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = It waves its leaf around to keep foes at bay. However, a sweet fragrance also wafts from the leaf, creating a friendly atmosphere that becalms the battlers.
 Generation = 2
+Flags = Starter
 Evolutions = BAYLEEF,Level,16
 #-------------------------------
 [BAYLEEF]
@@ -4042,6 +4052,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = A Bayleef's neck is ringed by curled-up leaves. Inside each leaf is a small tree shoot. The fragrance of this shoot makes people peppy.
 Generation = 2
+Flags = Starter
 Evolutions = MEGANIUM,Level,32
 #-------------------------------
 [MEGANIUM]
@@ -4068,6 +4079,7 @@ Habitat = Grassland
 Category = Herb
 Pokedex = The fragrance of a Meganium's flower soothes and calms emotions. In battle, it gives off more of its becalming scent to blunt the foe's fighting spirit.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [CYNDAQUIL]
 Name = Cyndaquil
@@ -4094,6 +4106,7 @@ Habitat = Grassland
 Category = Fire Mouse
 Pokedex = It flares flames from its back to protect itself. The fire burns vigorously if the Pokémon is angry. When it is tired, it sputters with incomplete combustion.
 Generation = 2
+Flags = Starter
 Evolutions = QUILAVA,Level,14
 #-------------------------------
 [QUILAVA]
@@ -4120,6 +4133,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It intimidates foes with intense gusts of flames and superheated air. Its quick nimbleness lets it dodge attacks even while scorching an enemy.
 Generation = 2
+Flags = Starter
 Evolutions = TYPHLOSION,Level,36
 #-------------------------------
 [TYPHLOSION]
@@ -4146,6 +4160,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It can hide behind a shimmering heat haze that it creates using its intense flames. Typhlosion create blazing explosive blasts that burn everything to cinders.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [TOTODILE]
 Name = Totodile
@@ -4172,6 +4187,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Despite its small body, Totodile's jaws are very powerful. While it may think it is just playfully nipping, its bite has enough strength to cause serious injury.
 Generation = 2
+Flags = Starter
 Evolutions = CROCONAW,Level,18
 #-------------------------------
 [CROCONAW]
@@ -4198,6 +4214,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Once its jaws clamp down on its foe, it will absolutely not let go. Because the tips of its fangs are forked back like fishhooks, they become irremovably embedded.
 Generation = 2
+Flags = Starter
 Evolutions = FERALIGATR,Level,30
 #-------------------------------
 [FERALIGATR]
@@ -4224,6 +4241,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = It opens its huge mouth to intimidate enemies. In battle, it runs using its thick and powerful hind legs to charge the foe with incredible speed.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [SENTRET]
 Name = Sentret
@@ -6637,6 +6655,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = It makes its nest in a giant tree in the forest. It ferociously guards against anything nearing its territory. It is said to be the protector of the trees.
 Generation = 3
+Flags = Starter
 Evolutions = GROVYLE,Level,16
 #-------------------------------
 [GROVYLE]
@@ -6663,6 +6682,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = Leaves grow out of this Pokémon's body. They help obscure a Grovyle from the eyes of its enemies while it is in a thickly overgrown forest.
 Generation = 3
+Flags = Starter
 Evolutions = SCEPTILE,Level,36
 #-------------------------------
 [SCEPTILE]
@@ -6689,6 +6709,7 @@ Habitat = Forest
 Category = Forest
 Pokedex = In the jungle, its power is without equal. This Pokémon carefully grows trees and plants. It regulates its body temperature by basking in sunlight.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [TORCHIC]
 Name = Torchic
@@ -6715,6 +6736,7 @@ Habitat = Grassland
 Category = Chick
 Pokedex = If attacked, it strikes back by spitting balls of fire it forms in its stomach. A Torchic dislikes darkness because it can't see its surroundings.
 Generation = 3
+Flags = Starter
 Evolutions = COMBUSKEN,Level,16
 #-------------------------------
 [COMBUSKEN]
@@ -6741,6 +6763,7 @@ Habitat = Grassland
 Category = Young Fowl
 Pokedex = It lashes out with 10 kicks per second. Its strong fighting instinct compels it to keep up its offensive until the opponent gives up.
 Generation = 3
+Flags = Starter
 Evolutions = BLAZIKEN,Level,36
 #-------------------------------
 [BLAZIKEN]
@@ -6767,6 +6790,7 @@ Habitat = Grassland
 Category = Blaze
 Pokedex = It learns martial arts that use punches and kicks. Every several years, its old feathers burn off, and new, supple feathers grow back in their place.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [MUDKIP]
 Name = Mudkip
@@ -6793,6 +6817,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = On land, it can powerfully lift large boulders by planting its four feet and heaving. It sleeps by burying itself in soil at the water's edge.
 Generation = 3
+Flags = Starter
 Evolutions = MARSHTOMP,Level,16
 #-------------------------------
 [MARSHTOMP]
@@ -6819,6 +6844,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = Its toughened hind legs enable it to stand upright. Because it weakens if its skin dries out, it replenishes fluids by playing in mud.
 Generation = 3
+Flags = Starter
 Evolutions = SWAMPERT,Level,36
 #-------------------------------
 [SWAMPERT]
@@ -6845,6 +6871,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = If it senses the approach of a storm and a tidal wave, it protects its seaside nest by piling up boulders. It swims as fast as a jet ski.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [POOCHYENA]
 Name = Poochyena
@@ -10197,6 +10224,7 @@ Shape = Quadruped
 Category = Tiny Leaf
 Pokedex = Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.
 Generation = 4
+Flags = Starter
 Evolutions = GROTLE,Level,18
 #-------------------------------
 [GROTLE]
@@ -10222,6 +10250,7 @@ Shape = Quadruped
 Category = Grove
 Pokedex = It lives along water in forests. In the daytime, it leaves the forest to sunbathe its treed shell.
 Generation = 4
+Flags = Starter
 Evolutions = TORTERRA,Level,32
 #-------------------------------
 [TORTERRA]
@@ -10247,6 +10276,7 @@ Shape = Quadruped
 Category = Continent
 Pokedex = Small Pokémon occasionally gather on its unmoving back to begin building their nests.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [CHIMCHAR]
 Name = Chimchar
@@ -10272,6 +10302,7 @@ Shape = BipedalTail
 Category = Chimp
 Pokedex = It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps.
 Generation = 4
+Flags = Starter
 Evolutions = MONFERNO,Level,14
 #-------------------------------
 [MONFERNO]
@@ -10297,6 +10328,7 @@ Shape = BipedalTail
 Category = Playful
 Pokedex = To intimidate attackers, it stretches the fire on its tail to make itself appear bigger.
 Generation = 4
+Flags = Starter
 Evolutions = INFERNAPE,Level,36
 #-------------------------------
 [INFERNAPE]
@@ -10322,6 +10354,7 @@ Shape = BipedalTail
 Category = Flame
 Pokedex = It uses a special kind of martial arts involving all its limbs. Its fire never goes out.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [PIPLUP]
 Name = Piplup
@@ -10347,6 +10380,7 @@ Shape = Bipedal
 Category = Penguin
 Pokedex = Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.
 Generation = 4
+Flags = Starter
 Evolutions = PRINPLUP,Level,16
 #-------------------------------
 [PRINPLUP]
@@ -10372,6 +10406,7 @@ Shape = BipedalTail
 Category = Penguin
 Pokedex = It lives alone, away from others. Apparently, every one of them believes it is the most important.
 Generation = 4
+Flags = Starter
 Evolutions = EMPOLEON,Level,36
 #-------------------------------
 [EMPOLEON]
@@ -10397,6 +10432,7 @@ Shape = BipedalTail
 Category = Emperor
 Pokedex = The three horns that extend from its beak attest to its power. The leader has the biggest horns.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [STARLY]
 Name = Starly
@@ -12900,6 +12936,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They photosynthesize by bathing their tails in sunlight. When they are not feeling well, their tails droop.
 Generation = 5
+Flags = Starter
 Evolutions = SERVINE,Level,17
 #-------------------------------
 [SERVINE]
@@ -12925,6 +12962,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.
 Generation = 5
+Flags = Starter
 Evolutions = SERPERIOR,Level,36
 #-------------------------------
 [SERPERIOR]
@@ -12950,6 +12988,7 @@ Shape = Serpentine
 Category = Regal
 Pokedex = They raise their heads to intimidate opponents, but only give it their all when fighting a powerful opponent.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [TEPIG]
 Name = Tepig
@@ -12975,6 +13014,7 @@ Shape = Quadruped
 Category = Fire Pig
 Pokedex = It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.
 Generation = 5
+Flags = Starter
 Evolutions = PIGNITE,Level,17
 #-------------------------------
 [PIGNITE]
@@ -13000,6 +13040,7 @@ Shape = BipedalTail
 Category = Fire Pig
 Pokedex = Whatever it eats becomes fuel for the flame in its stomach. When it is angered, the intensity of the flame increases.
 Generation = 5
+Flags = Starter
 Evolutions = EMBOAR,Level,36
 #-------------------------------
 [EMBOAR]
@@ -13025,6 +13066,7 @@ Shape = BipedalTail
 Category = Mega Fire Pig
 Pokedex = It can throw a fire punch by setting its fists on fire with its fiery chin. It cares deeply about its friends.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [OSHAWOTT]
 Name = Oshawott
@@ -13050,6 +13092,7 @@ Shape = BipedalTail
 Category = Sea Otter
 Pokedex = The scalchop on its stomach is made from the same elements as claws. It detaches the scalchop for use as a blade.
 Generation = 5
+Flags = Starter
 Evolutions = DEWOTT,Level,17
 #-------------------------------
 [DEWOTT]
@@ -13075,6 +13118,7 @@ Shape = BipedalTail
 Category = Discipline
 Pokedex = Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.
 Generation = 5
+Flags = Starter
 Evolutions = SAMUROTT,Level,36
 #-------------------------------
 [SAMUROTT]
@@ -13100,6 +13144,7 @@ Shape = Quadruped
 Category = Formidable
 Pokedex = Part of the armor on its anterior legs becomes a giant sword. Its cry alone is enough to intimidate most enemies.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [PATRAT]
 Name = Patrat
@@ -16798,6 +16843,7 @@ Shape = BipedalTail
 Category = Spiny Nut
 Pokedex = The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.
 Generation = 6
+Flags = Starter
 Evolutions = QUILLADIN,Level,16
 #-------------------------------
 [QUILLADIN]
@@ -16823,6 +16869,7 @@ Shape = BipedalTail
 Category = Spiny Armor
 Pokedex = They strengthen their lower bodies by running into one another. They are very kind and won't start fights.
 Generation = 6
+Flags = Starter
 Evolutions = CHESNAUGHT,Level,36
 #-------------------------------
 [CHESNAUGHT]
@@ -16848,6 +16895,7 @@ Shape = BipedalTail
 Category = Spiny Armor
 Pokedex = Its Tackle is forceful enough to flip a 50-ton tank. It shields its allies from danger with its own body.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [FENNEKIN]
 Name = Fennekin
@@ -16873,6 +16921,7 @@ Shape = Quadruped
 Category = Fox
 Pokedex = As it walks, it munches on a twig in place of a snack. It intimidates opponents by puffing hot air out of its ears.
 Generation = 6
+Flags = Starter
 Evolutions = BRAIXEN,Level,16
 #-------------------------------
 [BRAIXEN]
@@ -16898,6 +16947,7 @@ Shape = BipedalTail
 Category = Fox
 Pokedex = When the twig is plucked from its tail, friction sets the twig alight. The flame is used to send signals to its allies.
 Generation = 6
+Flags = Starter
 Evolutions = DELPHOX,Level,36
 #-------------------------------
 [DELPHOX]
@@ -16923,6 +16973,7 @@ Shape = BipedalTail
 Category = Fox
 Pokedex = It gazes into the flame at the tip of its branch to achieve a focused state, which allows it to see into the future.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [FROAKIE]
 Name = Froakie
@@ -16948,6 +16999,7 @@ Shape = Quadruped
 Category = Bubble Frog
 Pokedex = It protects its skin by covering its body in delicate bubbles. Beneath its happy-go-lucky air, it keeps a watchful eye on its surroundings.
 Generation = 6
+Flags = Starter
 Evolutions = FROGADIER,Level,16
 #-------------------------------
 [FROGADIER]
@@ -16973,6 +17025,7 @@ Shape = Bipedal
 Category = Bubble Frog
 Pokedex = It can throw bubble-covered pebbles with precise control, hitting empty cans up to a hundred feet away.
 Generation = 6
+Flags = Starter
 Evolutions = GRENINJA,Level,36
 #-------------------------------
 [GRENINJA]
@@ -16998,6 +17051,7 @@ Shape = Bipedal
 Category = Ninja
 Pokedex = It appears and vanishes with a ninja’s grace. It toys with its enemies using swift movements, while slicing them with throwing stars of sharpest water.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [BUNNELBY]
 Name = Bunnelby
@@ -18598,6 +18652,7 @@ Shape = Winged
 Category = Grass Quill
 Pokedex = It sends its feathers, which are as sharp as blades, flying in attack. Its legs are strong, so its kicks are also formidable.
 Generation = 7
+Flags = Starter
 Evolutions = DARTRIX,Level,17
 #-------------------------------
 [DARTRIX]
@@ -18623,6 +18678,7 @@ Shape = Winged
 Category = Blade Quill
 Pokedex = A bit of a dandy, it spends its free time preening its wings. Its preoccupation with any dirt on its plumage can leave it unable to battle.
 Generation = 7
+Flags = Starter
 Evolutions = DECIDUEYE,Level,34
 #-------------------------------
 [DECIDUEYE]
@@ -18648,6 +18704,7 @@ Shape = Winged
 Category = Arrow Quill
 Pokedex = It fires arrow quills from its wings with such precision, they can pierce a pebble at distances over a hundred yards.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [LITTEN]
 Name = Litten
@@ -18673,6 +18730,7 @@ Shape = Quadruped
 Category = Fire Cat
 Pokedex = Its coat regrows twice a year. When the time comes, Litten sets its own body on fire and burns away the old fur.
 Generation = 7
+Flags = Starter
 Evolutions = TORRACAT,Level,17
 #-------------------------------
 [TORRACAT]
@@ -18698,6 +18756,7 @@ Shape = Quadruped
 Category = Fire Cat
 Pokedex = It can act spoiled if it grows close to its Trainer. A powerful Pokémon, its sharp claws can leave its Trainer's whole body covered in scratches.
 Generation = 7
+Flags = Starter
 Evolutions = INCINEROAR,Level,34
 #-------------------------------
 [INCINEROAR]
@@ -18723,6 +18782,7 @@ Shape = BipedalTail
 Category = Heel
 Pokedex = Although it's rough mannered and egotistical, it finds beating down unworthy opponents boring. It gets motivated for stronger opponents.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [POPPLIO]
 Name = Popplio
@@ -18748,6 +18808,7 @@ Shape = Finned
 Category = Sea Lion
 Pokedex = This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.
 Generation = 7
+Flags = Starter
 Evolutions = BRIONNE,Level,17
 #-------------------------------
 [BRIONNE]
@@ -18773,6 +18834,7 @@ Shape = Finned
 Category = Pop Star
 Pokedex = It gets excited when it sees a dance it doesn't know. This hard worker practices diligently until it can learn that dance.
 Generation = 7
+Flags = Starter
 Evolutions = PRIMARINA,Level,34
 #-------------------------------
 [PRIMARINA]
@@ -18798,6 +18860,7 @@ Shape = Finned
 Category = Soloist
 Pokedex = It controls its water balloons with song. The melody is learned from others of its kind and is passed down from one generation to the next.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [PIKIPEK]
 Name = Pikipek

--- a/PBS/Gen 8/pokemon.txt
+++ b/PBS/Gen 8/pokemon.txt
@@ -3820,6 +3820,7 @@ Habitat = Rare
 Category = Freeze
 Pokedex = Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [ZAPDOS]
 Name = Zapdos
@@ -3845,6 +3846,7 @@ Habitat = Rare
 Category = Electric
 Pokedex = Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. It gains power if it is stricken by lightning bolts.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MOLTRES]
 Name = Moltres
@@ -3870,6 +3872,7 @@ Habitat = Rare
 Category = Flame
 Pokedex = Moltres is a legendary bird Pokémon that can control fire. If injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [DRATINI]
 Name = Dratini
@@ -3976,6 +3979,7 @@ Habitat = Rare
 Category = Genetic
 Pokedex = A Pokémon that was created by genetic manipulation. However, even though the scientific power of humans made its body, they failed to give it a warm heart.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MEW]
 Name = Mew
@@ -6427,6 +6431,7 @@ Habitat = Grassland
 Category = Thunder
 Pokedex = Raikou embodies the speed of lightning. Its roars send shock waves shuddering through the air and ground as if lightning bolts were crashing down.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [ENTEI]
 Name = Entei
@@ -6452,6 +6457,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = Entei embodies the passion of magma. It is thought to have been born in the eruption of a volcano. It blasts fire that consumes all that it touches.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [SUICUNE]
 Name = Suicune
@@ -6477,6 +6483,7 @@ Habitat = Grassland
 Category = Aurora
 Pokedex = Suicune embodies the compassion of a pure spring of water. It runs across the land with gliding elegance. It has the power to purify dirty water.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [LARVITAR]
 Name = Larvitar
@@ -6579,6 +6586,7 @@ Habitat = Rare
 Category = Diving
 Pokedex = Lugia is so powerful even a light fluttering of its wings can blow apart houses. As a result, it chooses to live out of sight deep under the sea.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [HOOH]
 Name = Ho-Oh
@@ -6604,6 +6612,7 @@ Habitat = Rare
 Category = Rainbow
 Pokedex = Its feathers--which glow in seven colors depending on the angle at which light strikes them--are thought to bring joy. It is said to live at the foot of a rainbow.
 Generation = 2
+Flags = Legendary
 WildItemCommon = SACREDASH
 WildItemUncommon = SACREDASH
 WildItemRare = SACREDASH
@@ -9983,6 +9992,7 @@ Habitat = Cave
 Category = Rock Peak
 Pokedex = A Pokémon that is made entirely of rocks and boulders. If parts of its body chip off in battle, Regirock repairs itself by adding new rocks.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGICE]
 Name = Regice
@@ -10008,6 +10018,7 @@ Habitat = Cave
 Category = Iceberg
 Pokedex = Its entire body is made of Antarctic ice. After extensive studies, researchers believe the ice was formed during an ice age.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGISTEEL]
 Name = Registeel
@@ -10033,6 +10044,7 @@ Habitat = Cave
 Category = Iron
 Pokedex = Its body is harder than any other kind of metal. The body metal is composed of a mysterious substance. Not only is it hard, it shrinks and stretches flexibly.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIAS]
 Name = Latias
@@ -10057,6 +10069,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = They make a small herd of only several members. They rarely make contact with people or other Pokémon. They disappear if they sense enemies.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIOS]
 Name = Latios
@@ -10081,6 +10094,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = Even in hiding, it can detect the locations of others and sense their emotions since it has telepathy. Its intelligence allows it to understand human languages.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [KYOGRE]
 Name = Kyogre
@@ -10105,6 +10119,7 @@ Habitat = Sea
 Category = Sea Basin
 Pokedex = Kyogre has appeared in mythology as the creator of the sea. After long years of feuding with Groudon, it took to sleep at the bottom of the sea.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [GROUDON]
 Name = Groudon
@@ -10129,6 +10144,7 @@ Habitat = RoughTerrain
 Category = Continent
 Pokedex = Groudon has appeared in mythology as the creator of the land. It sleeps in magma underground and is said to make volcanoes erupt on awakening.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [RAYQUAZA]
 Name = Rayquaza
@@ -10153,6 +10169,7 @@ Habitat = Rare
 Category = Sky High
 Pokedex = A Pokémon that flies endlessly in the ozone layer. It is said it would descend to the ground if Kyogre and Groudon were to fight.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [JIRACHI]
 Name = Jirachi
@@ -12584,6 +12601,7 @@ Shape = BipedalTail
 Category = Knowledge
 Pokedex = Known as "The Being of Knowledge." It is said that it can wipe out the memory of those who see its eyes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [MESPRIT]
 Name = Mesprit
@@ -12607,6 +12625,7 @@ Shape = BipedalTail
 Category = Emotion
 Pokedex = Known as "The Being of Emotion." It taught humans the nobility of sorrow, pain, and joy.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [AZELF]
 Name = Azelf
@@ -12630,6 +12649,7 @@ Shape = BipedalTail
 Category = Willpower
 Pokedex = Known as "The Being of Willpower." It sleeps at the bottom of a lake to keep the world in balance.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [DIALGA]
 Name = Dialga
@@ -12654,6 +12674,7 @@ Shape = Quadruped
 Category = Temporal
 Pokedex = It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PALKIA]
 Name = Palkia
@@ -12678,6 +12699,7 @@ Shape = BipedalTail
 Category = Spatial
 Pokedex = It has the ability to distort space. It is described as a deity in Sinnoh-region mythology.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [HEATRAN]
 Name = Heatran
@@ -12702,6 +12724,7 @@ Shape = Quadruped
 Category = Lava Dome
 Pokedex = It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [REGIGIGAS]
 Name = Regigigas
@@ -12725,6 +12748,7 @@ Shape = Bipedal
 Category = Colossal
 Pokedex = There is an enduring legend that states this Pokémon towed continents with ropes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [GIRATINA]
 Name = Giratina
@@ -12750,6 +12774,7 @@ Category = Renegade
 Pokedex = A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery.
 FormName = Altered Forme
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [CRESSELIA]
 Name = Cresselia
@@ -12773,6 +12798,7 @@ Shape = Serpentine
 Category = Lunar
 Pokedex = Shiny particles are released from its wings like a veil. It is said to represent the crescent moon.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PHIONE]
 Name = Phione
@@ -16559,6 +16585,7 @@ Shape = Quadruped
 Category = Iron Will
 Pokedex = It has a body and heart of steel. Its glare is sufficient to make even an unruly Pokémon obey it.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TERRAKION]
 Name = Terrakion
@@ -16582,6 +16609,7 @@ Shape = Quadruped
 Category = Cavern
 Pokedex = Its charge is strong enough to break through a giant castle wall in one blow. This Pokémon is spoken of in legends.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [VIRIZION]
 Name = Virizion
@@ -16605,6 +16633,7 @@ Shape = Quadruped
 Category = Grassland
 Pokedex = Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TORNADUS]
 Name = Tornadus
@@ -16630,6 +16659,7 @@ Category = Cyclone
 Pokedex = Tornadus expels massive energy from its tail, causing severe storms. Its power is great enough to blow houses away.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [THUNDURUS]
 Name = Thundurus
@@ -16655,6 +16685,7 @@ Category = Bolt Strike
 Pokedex = The spikes on its tail discharge immense bolts of lightning. It flies around the Unova region firing off lightning bolts.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [RESHIRAM]
 Name = Reshiram
@@ -16678,6 +16709,7 @@ Shape = Winged
 Category = Vast White
 Pokedex = When Reshiram's tail flares, the heat energy moves the atmosphere and changes the world's weather.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [ZEKROM]
 Name = Zekrom
@@ -16701,6 +16733,7 @@ Shape = BipedalTail
 Category = Deep Black
 Pokedex = This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [LANDORUS]
 Name = Landorus
@@ -16726,6 +16759,7 @@ Category = Abundance
 Pokedex = The energy that comes pouring from its tail increases the nutrition in the soil, making crops grow to great size.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KYUREM]
 Name = Kyurem
@@ -16749,6 +16783,7 @@ Shape = BipedalTail
 Category = Boundary
 Pokedex = It generates a powerful, freezing energy inside itself, but its body became frozen when the energy leaked out.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KELDEO]
 Name = Keldeo
@@ -18516,6 +18551,7 @@ Category = Life
 Pokedex = Legends say it can share eternal life. It slept for a thousand years in the form of a tree before its revival.
 FormName = Neutral Mode
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [YVELTAL]
 Name = Yveltal
@@ -18539,6 +18575,7 @@ Shape = Winged
 Category = Destruction
 Pokedex = When its life comes to an end, it absorbs the life energy of every living thing and turns into a cocoon once more.
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [ZYGARDE]
 Name = Zygarde
@@ -18563,6 +18600,7 @@ Category = Order
 Pokedex = It's thought to be monitoring the ecosystem. There are rumors that even greater power lies hidden within it.
 FormName = 50% Forme
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [DIANCIE]
 Name = Diancie
@@ -19943,6 +19981,7 @@ Shape = Quadruped
 Category = Synthetic
 Pokedex = The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power.
 Generation = 7
+Flags = Legendary
 Evolutions = SILVALLY,Happiness,
 #-------------------------------
 [SILVALLY]
@@ -19968,6 +20007,7 @@ Category = Synthetic
 Pokedex = Its trust in its partner is what awakens it. This Pokémon is capable of changing its type, a flexibility that is well displayed in battle.
 FormName = Type: Normal
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [MINIOR]
 Name = Minior
@@ -20271,6 +20311,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = Although it's called a guardian deity, if a person or Pokémon puts it in a bad mood, it will become a malevolent deity and attack.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPULELE]
 Name = Tapu Lele
@@ -20295,6 +20336,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = As it flutters about, it scatters its strangely glowing scales. Touching them is said to restore good health on the spot.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPUBULU]
 Name = Tapu Bulu
@@ -20319,6 +20361,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = It pulls large trees up by the roots and swings them around. It causes vegetation to grow, and then it absorbs energy from the growth.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPUFINI]
 Name = Tapu Fini
@@ -20343,6 +20386,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = The dense fog it creates brings the downfall and destruction of its confused enemies. Ocean currents are the source of its energy.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [COSMOG]
 Name = Cosmog
@@ -20365,6 +20409,7 @@ Shape = Head
 Category = Nebula
 Pokedex = Whether or not it's a Pokémon from this world is a mystery. When it's in a jam, it warps away to a safe place to hide.
 Generation = 7
+Flags = Legendary
 Evolutions = COSMOEM,Level,43
 #-------------------------------
 [COSMOEM]
@@ -20389,6 +20434,7 @@ Shape = Head
 Category = Protostar
 Pokedex = Motionless as if dead, its body is faintly warm to the touch. In the distant past, it was called the cocoon of the stars.
 Generation = 7
+Flags = Legendary
 Evolutions = SOLGALEO,LevelDay,53,LUNALA,LevelNight,53
 #-------------------------------
 [SOLGALEO]
@@ -20413,6 +20459,7 @@ Shape = Quadruped
 Category = Sunne
 Pokedex = It is said to live in another world. The intense light it radiates from the surface of its body can make the darkest of nights light up like midday.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [LUNALA]
 Name = Lunala
@@ -20436,6 +20483,7 @@ Shape = Winged
 Category = Moone
 Pokedex = Said to live in another world, this Pokémon devours light, drawing the moonless dark veil of night over the brightness of day.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [NIHILEGO]
 Name = Nihilego
@@ -20627,6 +20675,7 @@ Shape = HeadArms
 Category = Prism
 Pokedex = Light is apparently the source of its energy. It has an extraordinarily vicious disposition and is constantly firing off laser beams.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [MAGEARNA]
 Name = Magearna
@@ -22883,6 +22932,7 @@ Shape = Winged
 Category = Gigantic
 Pokedex = The core on its chest absorbs energy emanating from the lands of the Galar region. This energy is what allows Eternatus to stay active.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [KUBFU]
 Name = Kubfu
@@ -22906,6 +22956,7 @@ Shape = BipedalTail
 Category = Wushu
 Pokedex = Kubfu trains hard to perfect its moves. The moves it masters will determine which form it takes when it evolves.
 Generation = 8
+Flags = Legendary
 Evolutions = URSHIFU,Event,1
 #-------------------------------
 [URSHIFU]
@@ -22931,6 +22982,7 @@ Category = Wushu
 Pokedex = Inhabiting the mountains of a distant region, this Pokémon races across sheer cliffs, training its legs and refining its moves.
 FormName = Single Strike Style
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [ZARUDE]
 Name = Zarude
@@ -22977,6 +23029,7 @@ Shape = Bipedal
 Category = Electron
 Pokedex = This Pokémon is a cluster of electrical energy. It's said that removing the rings on Regieleki's body will unleash the Pokémon's latent power.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [REGIDRAGO]
 Name = Regidrago
@@ -23000,6 +23053,7 @@ Shape = Bipedal
 Category = Dragon Orb
 Pokedex = Its body is composed of crystallized dragon energy. Regidrago is said to have the powers of every dragon Pokémon.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [GLASTRIER]
 Name = Glastrier
@@ -23023,6 +23077,7 @@ Shape = Quadruped
 Category = Wild Horse
 Pokedex = Glastrier has tremendous physical strength, and the mask of ice covering its face is 100 times harder than diamond.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [SPECTRIER]
 Name = Spectrier
@@ -23046,6 +23101,7 @@ Shape = Quadruped
 Category = Swift Horse
 Pokedex = As it dashes through the night, Spectrier absorbs the life-force of sleeping creatures. It craves silence and solitude.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [CALYREX]
 Name = Calyrex
@@ -23069,3 +23125,4 @@ Shape = Bipedal
 Category = King
 Pokedex = Calyrex is a merciful Pokémon, capable of providing healing and blessings. It reigned over the Galar region in times of yore.
 Generation = 8
+Flags = Legendary

--- a/PBS/Gen 8/pokemon.txt
+++ b/PBS/Gen 8/pokemon.txt
@@ -4004,6 +4004,7 @@ Habitat = Rare
 Category = New Species
 Pokedex = A Mew is said to possess the genes of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.
 Generation = 1
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -6640,6 +6641,7 @@ Habitat = Forest
 Category = Time Travel
 Pokedex = This Pokémon came from the future by crossing over time. It is thought that so long as Celebi appears, a bright and shining future awaits us.
 Generation = 2
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -10194,6 +10196,7 @@ Habitat = Mountain
 Category = Wish
 Pokedex = Jirachi is said to make wishes come true. While it sleeps, a tough crystalline shell envelops the body to protect it from enemies.
 Generation = 3
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -10222,6 +10225,7 @@ Category = DNA
 Pokedex = A Pokémon that mutated from an extraterrestrial virus exposed to a laser beam. Its body is configured for superior agility and speed.
 FormName = Normal Forme
 Generation = 3
+Flags = Mythical
 #-------------------------------
 [TURTWIG]
 Name = Turtwig
@@ -12822,6 +12826,7 @@ Shape = HeadArms
 Category = Sea Drifter
 Pokedex = A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [MANAPHY]
 Name = Manaphy
@@ -12846,6 +12851,7 @@ Shape = Bipedal
 Category = Seafaring
 Pokedex = Born on a cold seafloor, it will swim great distances to return to its birthplace.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [DARKRAI]
 Name = Darkrai
@@ -12869,6 +12875,7 @@ Shape = Bipedal
 Category = Pitch-Black
 Pokedex = It can lull people to sleep and make them dream. It is active during nights of the new moon.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [SHAYMIN]
 Name = Shaymin
@@ -12893,6 +12900,7 @@ Category = Gratitude
 Pokedex = It lives in flower patches and avoids detection by curling up to look like a flowering plant.
 FormName = Land Forme
 Generation = 4
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -12920,6 +12928,7 @@ Category = Alpha
 Pokedex = It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.
 FormName = Normal Type
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [VICTINI]
 Name = Victini
@@ -12943,6 +12952,7 @@ Shape = Bipedal
 Category = Victory
 Pokedex = This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [SNIVY]
 Name = Snivy
@@ -16808,6 +16818,7 @@ Category = Colt
 Pokedex = It crosses the world, running over the surfaces of oceans and rivers. It appears at scenic waterfronts.
 FormName = Ordinary Form
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [MELOETTA]
 Name = Meloetta
@@ -16832,6 +16843,7 @@ Category = Melody
 Pokedex = Many famous songs have been inspired by the melodies that Meloetta plays.
 FormName = Aria Forme
 Generation = 5
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -16859,6 +16871,7 @@ Category = Paleozoic
 Pokedex = This ancient bug Pokémon was altered by Team Plasma. They upgraded the cannon on its back.
 FormName = Normal
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [CHESPIN]
 Name = Chespin
@@ -18624,6 +18637,7 @@ Shape = HeadArms
 Category = Jewel
 Pokedex = A sudden transformation of Carbink, its pink, glimmering body is said to be the loveliest sight in the whole world.
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [HOOPA]
 Name = Hoopa
@@ -18648,6 +18662,7 @@ Category = Mischief
 Pokedex = This troublemaker sends anything and everything to faraway places using its loop, which can warp space.
 FormName = Hoopa Confined
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [VOLCANION]
 Name = Volcanion
@@ -18671,6 +18686,7 @@ Shape = Quadruped
 Category = Steam
 Pokedex = It lets out billows of steam and disappears into the dense fog. It's said to live in mountains where humans do not tread.
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [ROWLET]
 Name = Rowlet
@@ -20699,6 +20715,7 @@ Shape = Bipedal
 Category = Artificial
 Pokedex = This artificial Pokémon, constructed more than 500 years ago, can understand human speech but cannot itself speak.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [MARSHADOW]
 Name = Marshadow
@@ -20722,6 +20739,7 @@ Shape = Bipedal
 Category = Gloomdweller
 Pokedex = Able to conceal itself in shadows, it never appears before humans, so its very existence was the stuff of myth.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [POIPOLE]
 Name = Poipole
@@ -20842,6 +20860,7 @@ Shape = Bipedal
 Category = Thunderclap
 Pokedex = It approaches its enemies at the speed of lightning, then tears them limb from limb with its sharp claws.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [MELTAN]
 Name = Meltan
@@ -20865,6 +20884,7 @@ Shape = Head
 Category = Hex Nut
 Pokedex = It melts particles of iron and other metals found in the subsoil, so it can absorb them into its body of molten steel.
 Generation = 7
+Flags = Mythical
 Evolutions = MELMETAL,Level,45
 #-------------------------------
 [MELMETAL]
@@ -20889,6 +20909,7 @@ Shape = Bipedal
 Category = Hex Nut
 Pokedex = Revered long ago for its capacity to create iron from nothing, for some reason it has come back to life after 3,000 years.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [GROOKEY]
 Name = Grookey
@@ -23006,6 +23027,7 @@ Shape = BipedalTail
 Category = Rogue Monkey
 Pokedex = Once the vines on Zarude's body tear off, they become nutrients in the soil. This helps the plants of the forest grow.
 Generation = 8
+Flags = Mythical
 #-------------------------------
 [REGIELEKI]
 Name = Regieleki

--- a/PBS/Gen 8/pokemon.txt
+++ b/PBS/Gen 8/pokemon.txt
@@ -25,6 +25,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun's rays, the seed grows progressively larger.
 Generation = 1
+Flags = Starter
 Evolutions = IVYSAUR,Level,16
 #-------------------------------
 [IVYSAUR]
@@ -51,6 +52,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = To support its bulb, Ivysaur's legs grow sturdy. If it spends more time lying in the sunlight, the bud will soon bloom into a large flower.
 Generation = 1
+Flags = Starter
 Evolutions = VENUSAUR,Level,32
 #-------------------------------
 [VENUSAUR]
@@ -77,6 +79,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Venusaur's flower is said to take on vivid colors if it gets plenty of nutrition and sunlight. The flower's aroma soothes the emotions of people.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CHARMANDER]
 Name = Charmander
@@ -103,6 +106,7 @@ Habitat = Mountain
 Category = Lizard
 Pokedex = The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is happy, and blazes when it is enraged.
 Generation = 1
+Flags = Starter
 Evolutions = CHARMELEON,Level,16
 #-------------------------------
 [CHARMELEON]
@@ -129,6 +133,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = Without pity, its sharp claws destroy foes. If it encounters a strong enemy, it becomes agitated, and the flame on its tail flares with a bluish white color.
 Generation = 1
+Flags = Starter
 Evolutions = CHARIZARD,Level,36
 #-------------------------------
 [CHARIZARD]
@@ -155,6 +160,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = A Charizard flies about in search of strong opponents. It breathes intense flames that can melt any material. However, it will never torch a weaker foe.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [SQUIRTLE]
 Name = Squirtle
@@ -181,6 +187,7 @@ Habitat = WatersEdge
 Category = Tiny Turtle
 Pokedex = Its shell is not just for protection. Its rounded shape and the grooves on its surface minimize resistance in water, enabling Squirtle to swim at high speeds.
 Generation = 1
+Flags = Starter
 Evolutions = WARTORTLE,Level,16
 #-------------------------------
 [WARTORTLE]
@@ -207,6 +214,7 @@ Habitat = WatersEdge
 Category = Turtle
 Pokedex = Its large tail is covered with rich, thick fur that deepens in color with age. The scratches on its shell are evidence of this Pokémon's toughness in battle.
 Generation = 1
+Flags = Starter
 Evolutions = BLASTOISE,Level,36
 #-------------------------------
 [BLASTOISE]
@@ -233,6 +241,7 @@ Habitat = WatersEdge
 Category = Shellfish
 Pokedex = The waterspouts that protrude from its shell are highly accurate. Their bullets of water can precisely nail tin cans from a distance of over 160 feet.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CATERPIE]
 Name = Caterpie
@@ -1373,7 +1382,7 @@ Category = Scratch Cat
 Pokedex = Meowth withdraw their sharp claws into their paws to silently sneak about. For some reason, this Pokémon loves shiny coins that glitter with light.
 Generation = 1
 WildItemUncommon = QUICKCLAW
-Evolutions = PERSIAN,Level,28
+Evolutions = PERSIAN,Level,28,PERRSERKER,None,
 #-------------------------------
 [PERSIAN]
 Name = Persian
@@ -2198,6 +2207,7 @@ Category = Wild Duck
 Pokedex = It is always seen with a stick from a plant. Apparently, there are good sticks and bad sticks. This Pokémon occasionally fights with others over choice sticks.
 Generation = 1
 WildItemUncommon = LEEK
+Evolutions = SIRFETCHD,None,
 #-------------------------------
 [DODUO]
 Name = Doduo
@@ -3234,6 +3244,7 @@ Habitat = Urban
 Category = Barrier
 Pokedex = A Mr. Mime is a master of pantomime. It can convince others that something unseeable actually exists. Once believed, the imaginary object does become real.
 Generation = 1
+Evolutions = MRRIME,None,
 #-------------------------------
 [SCYTHER]
 Name = Scyther
@@ -4018,6 +4029,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = It waves its leaf around to keep foes at bay. However, a sweet fragrance also wafts from the leaf, creating a friendly atmosphere that becalms the battlers.
 Generation = 2
+Flags = Starter
 Evolutions = BAYLEEF,Level,16
 #-------------------------------
 [BAYLEEF]
@@ -4044,6 +4056,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = A Bayleef's neck is ringed by curled-up leaves. Inside each leaf is a small tree shoot. The fragrance of this shoot makes people peppy.
 Generation = 2
+Flags = Starter
 Evolutions = MEGANIUM,Level,32
 #-------------------------------
 [MEGANIUM]
@@ -4070,6 +4083,7 @@ Habitat = Grassland
 Category = Herb
 Pokedex = The fragrance of a Meganium's flower soothes and calms emotions. In battle, it gives off more of its becalming scent to blunt the foe's fighting spirit.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [CYNDAQUIL]
 Name = Cyndaquil
@@ -4096,6 +4110,7 @@ Habitat = Grassland
 Category = Fire Mouse
 Pokedex = It flares flames from its back to protect itself. The fire burns vigorously if the Pokémon is angry. When it is tired, it sputters with incomplete combustion.
 Generation = 2
+Flags = Starter
 Evolutions = QUILAVA,Level,14
 #-------------------------------
 [QUILAVA]
@@ -4122,6 +4137,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It intimidates foes with intense gusts of flames and superheated air. Its quick nimbleness lets it dodge attacks even while scorching an enemy.
 Generation = 2
+Flags = Starter
 Evolutions = TYPHLOSION,Level,36
 #-------------------------------
 [TYPHLOSION]
@@ -4148,6 +4164,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It can hide behind a shimmering heat haze that it creates using its intense flames. Typhlosion create blazing explosive blasts that burn everything to cinders.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [TOTODILE]
 Name = Totodile
@@ -4174,6 +4191,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Despite its small body, Totodile's jaws are very powerful. While it may think it is just playfully nipping, its bite has enough strength to cause serious injury.
 Generation = 2
+Flags = Starter
 Evolutions = CROCONAW,Level,18
 #-------------------------------
 [CROCONAW]
@@ -4200,6 +4218,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Once its jaws clamp down on its foe, it will absolutely not let go. Because the tips of its fangs are forked back like fishhooks, they become irremovably embedded.
 Generation = 2
+Flags = Starter
 Evolutions = FERALIGATR,Level,30
 #-------------------------------
 [FERALIGATR]
@@ -4226,6 +4245,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = It opens its huge mouth to intimidate enemies. In battle, it runs using its thick and powerful hind legs to charge the foe with incredible speed.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [SENTRET]
 Name = Sentret
@@ -5852,6 +5872,7 @@ Category = Coral
 Pokedex = Corsola live in warm southern seas. If the sea becomes polluted, the beautiful coral stalks become discolored and crumble away in tatters.
 Generation = 2
 WildItemUncommon = LUMINOUSMOSS
+Evolutions = CURSOLA,None,
 #-------------------------------
 [REMORAID]
 Name = Remoraid
@@ -6639,6 +6660,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = It makes its nest in a giant tree in the forest. It ferociously guards against anything nearing its territory. It is said to be the protector of the trees.
 Generation = 3
+Flags = Starter
 Evolutions = GROVYLE,Level,16
 #-------------------------------
 [GROVYLE]
@@ -6665,6 +6687,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = Leaves grow out of this Pokémon's body. They help obscure a Grovyle from the eyes of its enemies while it is in a thickly overgrown forest.
 Generation = 3
+Flags = Starter
 Evolutions = SCEPTILE,Level,36
 #-------------------------------
 [SCEPTILE]
@@ -6691,6 +6714,7 @@ Habitat = Forest
 Category = Forest
 Pokedex = In the jungle, its power is without equal. This Pokémon carefully grows trees and plants. It regulates its body temperature by basking in sunlight.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [TORCHIC]
 Name = Torchic
@@ -6717,6 +6741,7 @@ Habitat = Grassland
 Category = Chick
 Pokedex = If attacked, it strikes back by spitting balls of fire it forms in its stomach. A Torchic dislikes darkness because it can't see its surroundings.
 Generation = 3
+Flags = Starter
 Evolutions = COMBUSKEN,Level,16
 #-------------------------------
 [COMBUSKEN]
@@ -6743,6 +6768,7 @@ Habitat = Grassland
 Category = Young Fowl
 Pokedex = It lashes out with 10 kicks per second. Its strong fighting instinct compels it to keep up its offensive until the opponent gives up.
 Generation = 3
+Flags = Starter
 Evolutions = BLAZIKEN,Level,36
 #-------------------------------
 [BLAZIKEN]
@@ -6769,6 +6795,7 @@ Habitat = Grassland
 Category = Blaze
 Pokedex = It learns martial arts that use punches and kicks. Every several years, its old feathers burn off, and new, supple feathers grow back in their place.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [MUDKIP]
 Name = Mudkip
@@ -6795,6 +6822,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = On land, it can powerfully lift large boulders by planting its four feet and heaving. It sleeps by burying itself in soil at the water's edge.
 Generation = 3
+Flags = Starter
 Evolutions = MARSHTOMP,Level,16
 #-------------------------------
 [MARSHTOMP]
@@ -6821,6 +6849,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = Its toughened hind legs enable it to stand upright. Because it weakens if its skin dries out, it replenishes fluids by playing in mud.
 Generation = 3
+Flags = Starter
 Evolutions = SWAMPERT,Level,36
 #-------------------------------
 [SWAMPERT]
@@ -6847,6 +6876,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = If it senses the approach of a storm and a tidal wave, it protects its seaside nest by piling up boulders. It swims as fast as a jet ski.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [POOCHYENA]
 Name = Poochyena
@@ -6955,6 +6985,7 @@ Pokedex = It is exceedingly fast if it only has to run in a straight line. When 
 Generation = 3
 WildItemCommon = POTION
 WildItemUncommon = MAXREVIVE
+Evolutions = OBSTAGOON,None,
 #-------------------------------
 [WURMPLE]
 Name = Wurmple
@@ -10199,6 +10230,7 @@ Shape = Quadruped
 Category = Tiny Leaf
 Pokedex = Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.
 Generation = 4
+Flags = Starter
 Evolutions = GROTLE,Level,18
 #-------------------------------
 [GROTLE]
@@ -10224,6 +10256,7 @@ Shape = Quadruped
 Category = Grove
 Pokedex = It lives along water in forests. In the daytime, it leaves the forest to sunbathe its treed shell.
 Generation = 4
+Flags = Starter
 Evolutions = TORTERRA,Level,32
 #-------------------------------
 [TORTERRA]
@@ -10249,6 +10282,7 @@ Shape = Quadruped
 Category = Continent
 Pokedex = Small Pokémon occasionally gather on its unmoving back to begin building their nests.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [CHIMCHAR]
 Name = Chimchar
@@ -10274,6 +10308,7 @@ Shape = BipedalTail
 Category = Chimp
 Pokedex = It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps.
 Generation = 4
+Flags = Starter
 Evolutions = MONFERNO,Level,14
 #-------------------------------
 [MONFERNO]
@@ -10299,6 +10334,7 @@ Shape = BipedalTail
 Category = Playful
 Pokedex = To intimidate attackers, it stretches the fire on its tail to make itself appear bigger.
 Generation = 4
+Flags = Starter
 Evolutions = INFERNAPE,Level,36
 #-------------------------------
 [INFERNAPE]
@@ -10324,6 +10360,7 @@ Shape = BipedalTail
 Category = Flame
 Pokedex = It uses a special kind of martial arts involving all its limbs. Its fire never goes out.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [PIPLUP]
 Name = Piplup
@@ -10349,6 +10386,7 @@ Shape = Bipedal
 Category = Penguin
 Pokedex = Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.
 Generation = 4
+Flags = Starter
 Evolutions = PRINPLUP,Level,16
 #-------------------------------
 [PRINPLUP]
@@ -10374,6 +10412,7 @@ Shape = BipedalTail
 Category = Penguin
 Pokedex = It lives alone, away from others. Apparently, every one of them believes it is the most important.
 Generation = 4
+Flags = Starter
 Evolutions = EMPOLEON,Level,36
 #-------------------------------
 [EMPOLEON]
@@ -10399,6 +10438,7 @@ Shape = BipedalTail
 Category = Emperor
 Pokedex = The three horns that extend from its beak attest to its power. The leader has the biggest horns.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [STARLY]
 Name = Starly
@@ -12902,6 +12942,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They photosynthesize by bathing their tails in sunlight. When they are not feeling well, their tails droop.
 Generation = 5
+Flags = Starter
 Evolutions = SERVINE,Level,17
 #-------------------------------
 [SERVINE]
@@ -12927,6 +12968,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.
 Generation = 5
+Flags = Starter
 Evolutions = SERPERIOR,Level,36
 #-------------------------------
 [SERPERIOR]
@@ -12952,6 +12994,7 @@ Shape = Serpentine
 Category = Regal
 Pokedex = They raise their heads to intimidate opponents, but only give it their all when fighting a powerful opponent.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [TEPIG]
 Name = Tepig
@@ -12977,6 +13020,7 @@ Shape = Quadruped
 Category = Fire Pig
 Pokedex = It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.
 Generation = 5
+Flags = Starter
 Evolutions = PIGNITE,Level,17
 #-------------------------------
 [PIGNITE]
@@ -13002,6 +13046,7 @@ Shape = BipedalTail
 Category = Fire Pig
 Pokedex = Whatever it eats becomes fuel for the flame in its stomach. When it is angered, the intensity of the flame increases.
 Generation = 5
+Flags = Starter
 Evolutions = EMBOAR,Level,36
 #-------------------------------
 [EMBOAR]
@@ -13027,6 +13072,7 @@ Shape = BipedalTail
 Category = Mega Fire Pig
 Pokedex = It can throw a fire punch by setting its fists on fire with its fiery chin. It cares deeply about its friends.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [OSHAWOTT]
 Name = Oshawott
@@ -13052,6 +13098,7 @@ Shape = BipedalTail
 Category = Sea Otter
 Pokedex = The scalchop on its stomach is made from the same elements as claws. It detaches the scalchop for use as a blade.
 Generation = 5
+Flags = Starter
 Evolutions = DEWOTT,Level,17
 #-------------------------------
 [DEWOTT]
@@ -13077,6 +13124,7 @@ Shape = BipedalTail
 Category = Discipline
 Pokedex = Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.
 Generation = 5
+Flags = Starter
 Evolutions = SAMUROTT,Level,36
 #-------------------------------
 [SAMUROTT]
@@ -13102,6 +13150,7 @@ Shape = Quadruped
 Category = Formidable
 Pokedex = Part of the armor on its anterior legs becomes a giant sword. Its cry alone is enough to intimidate most enemies.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [PATRAT]
 Name = Patrat
@@ -14607,7 +14656,7 @@ Category = Spirit
 Pokedex = These Pokémon arose from the spirits of people interred in graves in past ages. Each retains memories of its former life.
 Generation = 5
 WildItemUncommon = SPELLTAG
-Evolutions = COFAGRIGUS,Level,34
+Evolutions = COFAGRIGUS,Level,34,RUNERIGUS,None,
 #-------------------------------
 [COFAGRIGUS]
 Name = Cofagrigus
@@ -16800,6 +16849,7 @@ Shape = BipedalTail
 Category = Spiny Nut
 Pokedex = The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.
 Generation = 6
+Flags = Starter
 Evolutions = QUILLADIN,Level,16
 #-------------------------------
 [QUILLADIN]
@@ -16825,6 +16875,7 @@ Shape = BipedalTail
 Category = Spiny Armor
 Pokedex = They strengthen their lower bodies by running into one another. They are very kind and won't start fights.
 Generation = 6
+Flags = Starter
 Evolutions = CHESNAUGHT,Level,36
 #-------------------------------
 [CHESNAUGHT]
@@ -16850,6 +16901,7 @@ Shape = BipedalTail
 Category = Spiny Armor
 Pokedex = Its Tackle is forceful enough to flip a 50-ton tank. It shields its allies from danger with its own body.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [FENNEKIN]
 Name = Fennekin
@@ -16875,6 +16927,7 @@ Shape = Quadruped
 Category = Fox
 Pokedex = As it walks, it munches on a twig in place of a snack. It intimidates opponents by puffing hot air out of its ears.
 Generation = 6
+Flags = Starter
 Evolutions = BRAIXEN,Level,16
 #-------------------------------
 [BRAIXEN]
@@ -16900,6 +16953,7 @@ Shape = BipedalTail
 Category = Fox
 Pokedex = When the twig is plucked from its tail, friction sets the twig alight. The flame is used to send signals to its allies.
 Generation = 6
+Flags = Starter
 Evolutions = DELPHOX,Level,36
 #-------------------------------
 [DELPHOX]
@@ -16925,6 +16979,7 @@ Shape = BipedalTail
 Category = Fox
 Pokedex = It gazes into the flame at the tip of its branch to achieve a focused state, which allows it to see into the future.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [FROAKIE]
 Name = Froakie
@@ -16950,6 +17005,7 @@ Shape = Quadruped
 Category = Bubble Frog
 Pokedex = It protects its skin by covering its body in delicate bubbles. Beneath its happy-go-lucky air, it keeps a watchful eye on its surroundings.
 Generation = 6
+Flags = Starter
 Evolutions = FROGADIER,Level,16
 #-------------------------------
 [FROGADIER]
@@ -16975,6 +17031,7 @@ Shape = Bipedal
 Category = Bubble Frog
 Pokedex = It can throw bubble-covered pebbles with precise control, hitting empty cans up to a hundred feet away.
 Generation = 6
+Flags = Starter
 Evolutions = GRENINJA,Level,36
 #-------------------------------
 [GRENINJA]
@@ -17000,6 +17057,7 @@ Shape = Bipedal
 Category = Ninja
 Pokedex = It appears and vanishes with a ninja’s grace. It toys with its enemies using swift movements, while slicing them with throwing stars of sharpest water.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [BUNNELBY]
 Name = Bunnelby
@@ -18600,6 +18658,7 @@ Shape = Winged
 Category = Grass Quill
 Pokedex = It sends its feathers, which are as sharp as blades, flying in attack. Its legs are strong, so its kicks are also formidable.
 Generation = 7
+Flags = Starter
 Evolutions = DARTRIX,Level,17
 #-------------------------------
 [DARTRIX]
@@ -18625,6 +18684,7 @@ Shape = Winged
 Category = Blade Quill
 Pokedex = A bit of a dandy, it spends its free time preening its wings. Its preoccupation with any dirt on its plumage can leave it unable to battle.
 Generation = 7
+Flags = Starter
 Evolutions = DECIDUEYE,Level,34
 #-------------------------------
 [DECIDUEYE]
@@ -18650,6 +18710,7 @@ Shape = Winged
 Category = Arrow Quill
 Pokedex = It fires arrow quills from its wings with such precision, they can pierce a pebble at distances over a hundred yards.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [LITTEN]
 Name = Litten
@@ -18675,6 +18736,7 @@ Shape = Quadruped
 Category = Fire Cat
 Pokedex = Its coat regrows twice a year. When the time comes, Litten sets its own body on fire and burns away the old fur.
 Generation = 7
+Flags = Starter
 Evolutions = TORRACAT,Level,17
 #-------------------------------
 [TORRACAT]
@@ -18700,6 +18762,7 @@ Shape = Quadruped
 Category = Fire Cat
 Pokedex = It can act spoiled if it grows close to its Trainer. A powerful Pokémon, its sharp claws can leave its Trainer's whole body covered in scratches.
 Generation = 7
+Flags = Starter
 Evolutions = INCINEROAR,Level,34
 #-------------------------------
 [INCINEROAR]
@@ -18725,6 +18788,7 @@ Shape = BipedalTail
 Category = Heel
 Pokedex = Although it's rough mannered and egotistical, it finds beating down unworthy opponents boring. It gets motivated for stronger opponents.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [POPPLIO]
 Name = Popplio
@@ -18750,6 +18814,7 @@ Shape = Finned
 Category = Sea Lion
 Pokedex = This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.
 Generation = 7
+Flags = Starter
 Evolutions = BRIONNE,Level,17
 #-------------------------------
 [BRIONNE]
@@ -18775,6 +18840,7 @@ Shape = Finned
 Category = Pop Star
 Pokedex = It gets excited when it sees a dance it doesn't know. This hard worker practices diligently until it can learn that dance.
 Generation = 7
+Flags = Starter
 Evolutions = PRIMARINA,Level,34
 #-------------------------------
 [PRIMARINA]
@@ -18800,6 +18866,7 @@ Shape = Finned
 Category = Soloist
 Pokedex = It controls its water balloons with song. The melody is learned from others of its kind and is passed down from one generation to the next.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [PIKIPEK]
 Name = Pikipek
@@ -20798,6 +20865,7 @@ Shape = BipedalTail
 Category = Chimp
 Pokedex = When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.
 Generation = 8
+Flags = Starter
 Evolutions = THWACKEY,Level,16
 #-------------------------------
 [THWACKEY]
@@ -20823,6 +20891,7 @@ Shape = BipedalTail
 Category = Beat
 Pokedex = When it's drumming out rapid beats in battle, it gets so caught up in the rhythm that it won't even notice that it's already knocked out its opponent.
 Generation = 8
+Flags = Starter
 Evolutions = RILLABOOM,Level,35
 #-------------------------------
 [RILLABOOM]
@@ -20848,6 +20917,7 @@ Shape = Bipedal
 Category = Drummer
 Pokedex = By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle.
 Generation = 8
+Flags = Starter
 #-------------------------------
 [SCORBUNNY]
 Name = Scorbunny
@@ -20873,6 +20943,7 @@ Shape = BipedalTail
 Category = Rabbit
 Pokedex = A warm-up of running around gets fire energy coursing through this Pokémon's body. Once that happens, it's ready to fight at full power.
 Generation = 8
+Flags = Starter
 Evolutions = RABOOT,Level,16
 #-------------------------------
 [RABOOT]
@@ -20898,6 +20969,7 @@ Shape = BipedalTail
 Category = Rabbit
 Pokedex = It kicks berries right off the branches of trees and then juggles them with its feet, practicing its footwork.
 Generation = 8
+Flags = Starter
 Evolutions = CINDERACE,Level,35
 #-------------------------------
 [CINDERACE]
@@ -20923,6 +20995,7 @@ Shape = BipedalTail
 Category = Striker
 Pokedex = It juggles a pebble with its feet, turning it into a burning soccer ball. Its shots strike opponents hard and leave them scorched.
 Generation = 8
+Flags = Starter
 #-------------------------------
 [SOBBLE]
 Name = Sobble
@@ -20948,6 +21021,7 @@ Shape = Quadruped
 Category = Water Lizard
 Pokedex = When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping.
 Generation = 8
+Flags = Starter
 Evolutions = DRIZZILE,Level,16
 #-------------------------------
 [DRIZZILE]
@@ -20973,6 +21047,7 @@ Shape = BipedalTail
 Category = Water Lizard
 Pokedex = A clever combatant, this Pokémon battles using water balloons created with moisture secreted from its palms.
 Generation = 8
+Flags = Starter
 Evolutions = INTELEON,Level,35
 #-------------------------------
 [INTELEON]
@@ -20998,6 +21073,7 @@ Shape = BipedalTail
 Category = Secret Agent
 Pokedex = It has many hidden capabilities, such as fingertips that can shoot water and a membrane on its back that it can use to glide through the air.
 Generation = 8
+Flags = Starter
 #-------------------------------
 [SKWOVET]
 Name = Skwovet

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -3820,6 +3820,7 @@ Habitat = Rare
 Category = Freeze
 Pokedex = Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [ZAPDOS]
 Name = Zapdos
@@ -3845,6 +3846,7 @@ Habitat = Rare
 Category = Electric
 Pokedex = Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. It gains power if it is stricken by lightning bolts.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MOLTRES]
 Name = Moltres
@@ -3870,6 +3872,7 @@ Habitat = Rare
 Category = Flame
 Pokedex = Moltres is a legendary bird Pokémon that can control fire. If injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [DRATINI]
 Name = Dratini
@@ -3976,6 +3979,7 @@ Habitat = Rare
 Category = Genetic
 Pokedex = A Pokémon that was created by genetic manipulation. However, even though the scientific power of humans made its body, they failed to give it a warm heart.
 Generation = 1
+Flags = Legendary
 #-------------------------------
 [MEW]
 Name = Mew
@@ -6427,6 +6431,7 @@ Habitat = Grassland
 Category = Thunder
 Pokedex = Raikou embodies the speed of lightning. Its roars send shock waves shuddering through the air and ground as if lightning bolts were crashing down.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [ENTEI]
 Name = Entei
@@ -6452,6 +6457,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = Entei embodies the passion of magma. It is thought to have been born in the eruption of a volcano. It blasts fire that consumes all that it touches.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [SUICUNE]
 Name = Suicune
@@ -6477,6 +6483,7 @@ Habitat = Grassland
 Category = Aurora
 Pokedex = Suicune embodies the compassion of a pure spring of water. It runs across the land with gliding elegance. It has the power to purify dirty water.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [LARVITAR]
 Name = Larvitar
@@ -6579,6 +6586,7 @@ Habitat = Rare
 Category = Diving
 Pokedex = Lugia is so powerful even a light fluttering of its wings can blow apart houses. As a result, it chooses to live out of sight deep under the sea.
 Generation = 2
+Flags = Legendary
 #-------------------------------
 [HOOH]
 Name = Ho-Oh
@@ -6604,6 +6612,7 @@ Habitat = Rare
 Category = Rainbow
 Pokedex = Its feathers--which glow in seven colors depending on the angle at which light strikes them--are thought to bring joy. It is said to live at the foot of a rainbow.
 Generation = 2
+Flags = Legendary
 WildItemCommon = SACREDASH
 WildItemUncommon = SACREDASH
 WildItemRare = SACREDASH
@@ -9983,6 +9992,7 @@ Habitat = Cave
 Category = Rock Peak
 Pokedex = A Pokémon that is made entirely of rocks and boulders. If parts of its body chip off in battle, Regirock repairs itself by adding new rocks.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGICE]
 Name = Regice
@@ -10008,6 +10018,7 @@ Habitat = Cave
 Category = Iceberg
 Pokedex = Its entire body is made of Antarctic ice. After extensive studies, researchers believe the ice was formed during an ice age.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [REGISTEEL]
 Name = Registeel
@@ -10033,6 +10044,7 @@ Habitat = Cave
 Category = Iron
 Pokedex = Its body is harder than any other kind of metal. The body metal is composed of a mysterious substance. Not only is it hard, it shrinks and stretches flexibly.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIAS]
 Name = Latias
@@ -10057,6 +10069,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = They make a small herd of only several members. They rarely make contact with people or other Pokémon. They disappear if they sense enemies.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [LATIOS]
 Name = Latios
@@ -10081,6 +10094,7 @@ Habitat = WatersEdge
 Category = Eon
 Pokedex = Even in hiding, it can detect the locations of others and sense their emotions since it has telepathy. Its intelligence allows it to understand human languages.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [KYOGRE]
 Name = Kyogre
@@ -10105,6 +10119,7 @@ Habitat = Sea
 Category = Sea Basin
 Pokedex = Kyogre has appeared in mythology as the creator of the sea. After long years of feuding with Groudon, it took to sleep at the bottom of the sea.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [GROUDON]
 Name = Groudon
@@ -10129,6 +10144,7 @@ Habitat = RoughTerrain
 Category = Continent
 Pokedex = Groudon has appeared in mythology as the creator of the land. It sleeps in magma underground and is said to make volcanoes erupt on awakening.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [RAYQUAZA]
 Name = Rayquaza
@@ -10153,6 +10169,7 @@ Habitat = Rare
 Category = Sky High
 Pokedex = A Pokémon that flies endlessly in the ozone layer. It is said it would descend to the ground if Kyogre and Groudon were to fight.
 Generation = 3
+Flags = Legendary
 #-------------------------------
 [JIRACHI]
 Name = Jirachi
@@ -12584,6 +12601,7 @@ Shape = BipedalTail
 Category = Knowledge
 Pokedex = Known as "The Being of Knowledge." It is said that it can wipe out the memory of those who see its eyes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [MESPRIT]
 Name = Mesprit
@@ -12607,6 +12625,7 @@ Shape = BipedalTail
 Category = Emotion
 Pokedex = Known as "The Being of Emotion." It taught humans the nobility of sorrow, pain, and joy.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [AZELF]
 Name = Azelf
@@ -12630,6 +12649,7 @@ Shape = BipedalTail
 Category = Willpower
 Pokedex = Known as "The Being of Willpower." It sleeps at the bottom of a lake to keep the world in balance.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [DIALGA]
 Name = Dialga
@@ -12654,6 +12674,7 @@ Shape = Quadruped
 Category = Temporal
 Pokedex = It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PALKIA]
 Name = Palkia
@@ -12678,6 +12699,7 @@ Shape = BipedalTail
 Category = Spatial
 Pokedex = It has the ability to distort space. It is described as a deity in Sinnoh-region mythology.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [HEATRAN]
 Name = Heatran
@@ -12702,6 +12724,7 @@ Shape = Quadruped
 Category = Lava Dome
 Pokedex = It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [REGIGIGAS]
 Name = Regigigas
@@ -12725,6 +12748,7 @@ Shape = Bipedal
 Category = Colossal
 Pokedex = There is an enduring legend that states this Pokémon towed continents with ropes.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [GIRATINA]
 Name = Giratina
@@ -12750,6 +12774,7 @@ Category = Renegade
 Pokedex = A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery.
 FormName = Altered Forme
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [CRESSELIA]
 Name = Cresselia
@@ -12773,6 +12798,7 @@ Shape = Serpentine
 Category = Lunar
 Pokedex = Shiny particles are released from its wings like a veil. It is said to represent the crescent moon.
 Generation = 4
+Flags = Legendary
 #-------------------------------
 [PHIONE]
 Name = Phione
@@ -16559,6 +16585,7 @@ Shape = Quadruped
 Category = Iron Will
 Pokedex = It has a body and heart of steel. Its glare is sufficient to make even an unruly Pokémon obey it.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TERRAKION]
 Name = Terrakion
@@ -16582,6 +16609,7 @@ Shape = Quadruped
 Category = Cavern
 Pokedex = Its charge is strong enough to break through a giant castle wall in one blow. This Pokémon is spoken of in legends.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [VIRIZION]
 Name = Virizion
@@ -16605,6 +16633,7 @@ Shape = Quadruped
 Category = Grassland
 Pokedex = Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [TORNADUS]
 Name = Tornadus
@@ -16630,6 +16659,7 @@ Category = Cyclone
 Pokedex = Tornadus expels massive energy from its tail, causing severe storms. Its power is great enough to blow houses away.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [THUNDURUS]
 Name = Thundurus
@@ -16655,6 +16685,7 @@ Category = Bolt Strike
 Pokedex = The spikes on its tail discharge immense bolts of lightning. It flies around the Unova region firing off lightning bolts.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [RESHIRAM]
 Name = Reshiram
@@ -16678,6 +16709,7 @@ Shape = Winged
 Category = Vast White
 Pokedex = When Reshiram's tail flares, the heat energy moves the atmosphere and changes the world's weather.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [ZEKROM]
 Name = Zekrom
@@ -16701,6 +16733,7 @@ Shape = BipedalTail
 Category = Deep Black
 Pokedex = This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [LANDORUS]
 Name = Landorus
@@ -16726,6 +16759,7 @@ Category = Abundance
 Pokedex = The energy that comes pouring from its tail increases the nutrition in the soil, making crops grow to great size.
 FormName = Incarnate Forme
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KYUREM]
 Name = Kyurem
@@ -16749,6 +16783,7 @@ Shape = BipedalTail
 Category = Boundary
 Pokedex = It generates a powerful, freezing energy inside itself, but its body became frozen when the energy leaked out.
 Generation = 5
+Flags = Legendary
 #-------------------------------
 [KELDEO]
 Name = Keldeo
@@ -18516,6 +18551,7 @@ Category = Life
 Pokedex = Legends say it can share eternal life. It slept for a thousand years in the form of a tree before its revival.
 FormName = Neutral Mode
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [YVELTAL]
 Name = Yveltal
@@ -18539,6 +18575,7 @@ Shape = Winged
 Category = Destruction
 Pokedex = When its life comes to an end, it absorbs the life energy of every living thing and turns into a cocoon once more.
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [ZYGARDE]
 Name = Zygarde
@@ -18563,6 +18600,7 @@ Category = Order
 Pokedex = It's thought to be monitoring the ecosystem. There are rumors that even greater power lies hidden within it.
 FormName = 50% Forme
 Generation = 6
+Flags = Legendary
 #-------------------------------
 [DIANCIE]
 Name = Diancie
@@ -19943,6 +19981,7 @@ Shape = Quadruped
 Category = Synthetic
 Pokedex = The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power.
 Generation = 7
+Flags = Legendary
 Evolutions = SILVALLY,Happiness,
 #-------------------------------
 [SILVALLY]
@@ -19968,6 +20007,7 @@ Category = Synthetic
 Pokedex = Its trust in its partner is what awakens it. This Pokémon is capable of changing its type, a flexibility that is well displayed in battle.
 FormName = Type: Normal
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [MINIOR]
 Name = Minior
@@ -20271,6 +20311,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = Although it's called a guardian deity, if a person or Pokémon puts it in a bad mood, it will become a malevolent deity and attack.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPULELE]
 Name = Tapu Lele
@@ -20295,6 +20336,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = As it flutters about, it scatters its strangely glowing scales. Touching them is said to restore good health on the spot.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPUBULU]
 Name = Tapu Bulu
@@ -20319,6 +20361,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = It pulls large trees up by the roots and swings them around. It causes vegetation to grow, and then it absorbs energy from the growth.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [TAPUFINI]
 Name = Tapu Fini
@@ -20343,6 +20386,7 @@ Shape = HeadArms
 Category = Land Spirit
 Pokedex = The dense fog it creates brings the downfall and destruction of its confused enemies. Ocean currents are the source of its energy.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [COSMOG]
 Name = Cosmog
@@ -20365,6 +20409,7 @@ Shape = Head
 Category = Nebula
 Pokedex = Whether or not it's a Pokémon from this world is a mystery. When it's in a jam, it warps away to a safe place to hide.
 Generation = 7
+Flags = Legendary
 Evolutions = COSMOEM,Level,43
 #-------------------------------
 [COSMOEM]
@@ -20389,6 +20434,7 @@ Shape = Head
 Category = Protostar
 Pokedex = Motionless as if dead, its body is faintly warm to the touch. In the distant past, it was called the cocoon of the stars.
 Generation = 7
+Flags = Legendary
 Evolutions = SOLGALEO,LevelDay,53,LUNALA,LevelNight,53
 #-------------------------------
 [SOLGALEO]
@@ -20413,6 +20459,7 @@ Shape = Quadruped
 Category = Sunne
 Pokedex = It is said to live in another world. The intense light it radiates from the surface of its body can make the darkest of nights light up like midday.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [LUNALA]
 Name = Lunala
@@ -20436,6 +20483,7 @@ Shape = Winged
 Category = Moone
 Pokedex = Said to live in another world, this Pokémon devours light, drawing the moonless dark veil of night over the brightness of day.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [NIHILEGO]
 Name = Nihilego
@@ -20627,6 +20675,7 @@ Shape = HeadArms
 Category = Prism
 Pokedex = Light is apparently the source of its energy. It has an extraordinarily vicious disposition and is constantly firing off laser beams.
 Generation = 7
+Flags = Legendary
 #-------------------------------
 [MAGEARNA]
 Name = Magearna
@@ -22883,6 +22932,7 @@ Shape = Winged
 Category = Gigantic
 Pokedex = The core on its chest absorbs energy emanating from the lands of the Galar region. This energy is what allows Eternatus to stay active.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [KUBFU]
 Name = Kubfu
@@ -22906,6 +22956,7 @@ Shape = BipedalTail
 Category = Wushu
 Pokedex = Kubfu trains hard to perfect its moves. The moves it masters will determine which form it takes when it evolves.
 Generation = 8
+Flags = Legendary
 Evolutions = URSHIFU,Event,1
 #-------------------------------
 [URSHIFU]
@@ -22931,6 +22982,7 @@ Category = Wushu
 Pokedex = Inhabiting the mountains of a distant region, this Pokémon races across sheer cliffs, training its legs and refining its moves.
 FormName = Single Strike Style
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [ZARUDE]
 Name = Zarude
@@ -22977,6 +23029,7 @@ Shape = Bipedal
 Category = Electron
 Pokedex = This Pokémon is a cluster of electrical energy. It's said that removing the rings on Regieleki's body will unleash the Pokémon's latent power.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [REGIDRAGO]
 Name = Regidrago
@@ -23000,6 +23053,7 @@ Shape = Bipedal
 Category = Dragon Orb
 Pokedex = Its body is composed of crystallized dragon energy. Regidrago is said to have the powers of every dragon Pokémon.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [GLASTRIER]
 Name = Glastrier
@@ -23023,6 +23077,7 @@ Shape = Quadruped
 Category = Wild Horse
 Pokedex = Glastrier has tremendous physical strength, and the mask of ice covering its face is 100 times harder than diamond.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [SPECTRIER]
 Name = Spectrier
@@ -23046,6 +23101,7 @@ Shape = Quadruped
 Category = Swift Horse
 Pokedex = As it dashes through the night, Spectrier absorbs the life-force of sleeping creatures. It craves silence and solitude.
 Generation = 8
+Flags = Legendary
 #-------------------------------
 [CALYREX]
 Name = Calyrex
@@ -23069,3 +23125,4 @@ Shape = Bipedal
 Category = King
 Pokedex = Calyrex is a merciful Pokémon, capable of providing healing and blessings. It reigned over the Galar region in times of yore.
 Generation = 8
+Flags = Legendary

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -4004,6 +4004,7 @@ Habitat = Rare
 Category = New Species
 Pokedex = A Mew is said to possess the genes of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.
 Generation = 1
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -6640,6 +6641,7 @@ Habitat = Forest
 Category = Time Travel
 Pokedex = This Pokémon came from the future by crossing over time. It is thought that so long as Celebi appears, a bright and shining future awaits us.
 Generation = 2
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -10194,6 +10196,7 @@ Habitat = Mountain
 Category = Wish
 Pokedex = Jirachi is said to make wishes come true. While it sleeps, a tough crystalline shell envelops the body to protect it from enemies.
 Generation = 3
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -10222,6 +10225,7 @@ Category = DNA
 Pokedex = A Pokémon that mutated from an extraterrestrial virus exposed to a laser beam. Its body is configured for superior agility and speed.
 FormName = Normal Forme
 Generation = 3
+Flags = Mythical
 #-------------------------------
 [TURTWIG]
 Name = Turtwig
@@ -12822,6 +12826,7 @@ Shape = HeadArms
 Category = Sea Drifter
 Pokedex = A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [MANAPHY]
 Name = Manaphy
@@ -12846,6 +12851,7 @@ Shape = Bipedal
 Category = Seafaring
 Pokedex = Born on a cold seafloor, it will swim great distances to return to its birthplace.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [DARKRAI]
 Name = Darkrai
@@ -12869,6 +12875,7 @@ Shape = Bipedal
 Category = Pitch-Black
 Pokedex = It can lull people to sleep and make them dream. It is active during nights of the new moon.
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [SHAYMIN]
 Name = Shaymin
@@ -12893,6 +12900,7 @@ Category = Gratitude
 Pokedex = It lives in flower patches and avoids detection by curling up to look like a flowering plant.
 FormName = Land Forme
 Generation = 4
+Flags = Mythical
 WildItemCommon = LUMBERRY
 WildItemUncommon = LUMBERRY
 WildItemRare = LUMBERRY
@@ -12920,6 +12928,7 @@ Category = Alpha
 Pokedex = It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.
 FormName = Normal Type
 Generation = 4
+Flags = Mythical
 #-------------------------------
 [VICTINI]
 Name = Victini
@@ -12943,6 +12952,7 @@ Shape = Bipedal
 Category = Victory
 Pokedex = This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [SNIVY]
 Name = Snivy
@@ -16808,6 +16818,7 @@ Category = Colt
 Pokedex = It crosses the world, running over the surfaces of oceans and rivers. It appears at scenic waterfronts.
 FormName = Ordinary Form
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [MELOETTA]
 Name = Meloetta
@@ -16832,6 +16843,7 @@ Category = Melody
 Pokedex = Many famous songs have been inspired by the melodies that Meloetta plays.
 FormName = Aria Forme
 Generation = 5
+Flags = Mythical
 WildItemCommon = STARPIECE
 WildItemUncommon = STARPIECE
 WildItemRare = STARPIECE
@@ -16859,6 +16871,7 @@ Category = Paleozoic
 Pokedex = This ancient bug Pokémon was altered by Team Plasma. They upgraded the cannon on its back.
 FormName = Normal
 Generation = 5
+Flags = Mythical
 #-------------------------------
 [CHESPIN]
 Name = Chespin
@@ -18624,6 +18637,7 @@ Shape = HeadArms
 Category = Jewel
 Pokedex = A sudden transformation of Carbink, its pink, glimmering body is said to be the loveliest sight in the whole world.
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [HOOPA]
 Name = Hoopa
@@ -18648,6 +18662,7 @@ Category = Mischief
 Pokedex = This troublemaker sends anything and everything to faraway places using its loop, which can warp space.
 FormName = Hoopa Confined
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [VOLCANION]
 Name = Volcanion
@@ -18671,6 +18686,7 @@ Shape = Quadruped
 Category = Steam
 Pokedex = It lets out billows of steam and disappears into the dense fog. It's said to live in mountains where humans do not tread.
 Generation = 6
+Flags = Mythical
 #-------------------------------
 [ROWLET]
 Name = Rowlet
@@ -20699,6 +20715,7 @@ Shape = Bipedal
 Category = Artificial
 Pokedex = This artificial Pokémon, constructed more than 500 years ago, can understand human speech but cannot itself speak.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [MARSHADOW]
 Name = Marshadow
@@ -20722,6 +20739,7 @@ Shape = Bipedal
 Category = Gloomdweller
 Pokedex = Able to conceal itself in shadows, it never appears before humans, so its very existence was the stuff of myth.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [POIPOLE]
 Name = Poipole
@@ -20842,6 +20860,7 @@ Shape = Bipedal
 Category = Thunderclap
 Pokedex = It approaches its enemies at the speed of lightning, then tears them limb from limb with its sharp claws.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [MELTAN]
 Name = Meltan
@@ -20865,6 +20884,7 @@ Shape = Head
 Category = Hex Nut
 Pokedex = It melts particles of iron and other metals found in the subsoil, so it can absorb them into its body of molten steel.
 Generation = 7
+Flags = Mythical
 Evolutions = MELMETAL,Level,45
 #-------------------------------
 [MELMETAL]
@@ -20889,6 +20909,7 @@ Shape = Bipedal
 Category = Hex Nut
 Pokedex = Revered long ago for its capacity to create iron from nothing, for some reason it has come back to life after 3,000 years.
 Generation = 7
+Flags = Mythical
 #-------------------------------
 [GROOKEY]
 Name = Grookey
@@ -23006,6 +23027,7 @@ Shape = BipedalTail
 Category = Rogue Monkey
 Pokedex = Once the vines on Zarude's body tear off, they become nutrients in the soil. This helps the plants of the forest grow.
 Generation = 8
+Flags = Mythical
 #-------------------------------
 [REGIELEKI]
 Name = Regieleki

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -25,6 +25,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun's rays, the seed grows progressively larger.
 Generation = 1
+Flags = Starter
 Evolutions = IVYSAUR,Level,16
 #-------------------------------
 [IVYSAUR]
@@ -51,6 +52,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = To support its bulb, Ivysaur's legs grow sturdy. If it spends more time lying in the sunlight, the bud will soon bloom into a large flower.
 Generation = 1
+Flags = Starter
 Evolutions = VENUSAUR,Level,32
 #-------------------------------
 [VENUSAUR]
@@ -77,6 +79,7 @@ Habitat = Grassland
 Category = Seed
 Pokedex = Venusaur's flower is said to take on vivid colors if it gets plenty of nutrition and sunlight. The flower's aroma soothes the emotions of people.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CHARMANDER]
 Name = Charmander
@@ -103,6 +106,7 @@ Habitat = Mountain
 Category = Lizard
 Pokedex = The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is happy, and blazes when it is enraged.
 Generation = 1
+Flags = Starter
 Evolutions = CHARMELEON,Level,16
 #-------------------------------
 [CHARMELEON]
@@ -129,6 +133,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = Without pity, its sharp claws destroy foes. If it encounters a strong enemy, it becomes agitated, and the flame on its tail flares with a bluish white color.
 Generation = 1
+Flags = Starter
 Evolutions = CHARIZARD,Level,36
 #-------------------------------
 [CHARIZARD]
@@ -155,6 +160,7 @@ Habitat = Mountain
 Category = Flame
 Pokedex = A Charizard flies about in search of strong opponents. It breathes intense flames that can melt any material. However, it will never torch a weaker foe.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [SQUIRTLE]
 Name = Squirtle
@@ -181,6 +187,7 @@ Habitat = WatersEdge
 Category = Tiny Turtle
 Pokedex = Its shell is not just for protection. Its rounded shape and the grooves on its surface minimize resistance in water, enabling Squirtle to swim at high speeds.
 Generation = 1
+Flags = Starter
 Evolutions = WARTORTLE,Level,16
 #-------------------------------
 [WARTORTLE]
@@ -207,6 +214,7 @@ Habitat = WatersEdge
 Category = Turtle
 Pokedex = Its large tail is covered with rich, thick fur that deepens in color with age. The scratches on its shell are evidence of this Pokémon's toughness in battle.
 Generation = 1
+Flags = Starter
 Evolutions = BLASTOISE,Level,36
 #-------------------------------
 [BLASTOISE]
@@ -233,6 +241,7 @@ Habitat = WatersEdge
 Category = Shellfish
 Pokedex = The waterspouts that protrude from its shell are highly accurate. Their bullets of water can precisely nail tin cans from a distance of over 160 feet.
 Generation = 1
+Flags = Starter
 #-------------------------------
 [CATERPIE]
 Name = Caterpie
@@ -1373,7 +1382,7 @@ Category = Scratch Cat
 Pokedex = Meowth withdraw their sharp claws into their paws to silently sneak about. For some reason, this Pokémon loves shiny coins that glitter with light.
 Generation = 1
 WildItemUncommon = QUICKCLAW
-Evolutions = PERSIAN,Level,28
+Evolutions = PERSIAN,Level,28,PERRSERKER,None,
 #-------------------------------
 [PERSIAN]
 Name = Persian
@@ -2198,6 +2207,7 @@ Category = Wild Duck
 Pokedex = It is always seen with a stick from a plant. Apparently, there are good sticks and bad sticks. This Pokémon occasionally fights with others over choice sticks.
 Generation = 1
 WildItemUncommon = LEEK
+Evolutions = SIRFETCHD,None,
 #-------------------------------
 [DODUO]
 Name = Doduo
@@ -3234,6 +3244,7 @@ Habitat = Urban
 Category = Barrier
 Pokedex = A Mr. Mime is a master of pantomime. It can convince others that something unseeable actually exists. Once believed, the imaginary object does become real.
 Generation = 1
+Evolutions = MRRIME,None,
 #-------------------------------
 [SCYTHER]
 Name = Scyther
@@ -4018,6 +4029,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = It waves its leaf around to keep foes at bay. However, a sweet fragrance also wafts from the leaf, creating a friendly atmosphere that becalms the battlers.
 Generation = 2
+Flags = Starter
 Evolutions = BAYLEEF,Level,16
 #-------------------------------
 [BAYLEEF]
@@ -4044,6 +4056,7 @@ Habitat = Grassland
 Category = Leaf
 Pokedex = A Bayleef's neck is ringed by curled-up leaves. Inside each leaf is a small tree shoot. The fragrance of this shoot makes people peppy.
 Generation = 2
+Flags = Starter
 Evolutions = MEGANIUM,Level,32
 #-------------------------------
 [MEGANIUM]
@@ -4070,6 +4083,7 @@ Habitat = Grassland
 Category = Herb
 Pokedex = The fragrance of a Meganium's flower soothes and calms emotions. In battle, it gives off more of its becalming scent to blunt the foe's fighting spirit.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [CYNDAQUIL]
 Name = Cyndaquil
@@ -4096,6 +4110,7 @@ Habitat = Grassland
 Category = Fire Mouse
 Pokedex = It flares flames from its back to protect itself. The fire burns vigorously if the Pokémon is angry. When it is tired, it sputters with incomplete combustion.
 Generation = 2
+Flags = Starter
 Evolutions = QUILAVA,Level,14
 #-------------------------------
 [QUILAVA]
@@ -4122,6 +4137,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It intimidates foes with intense gusts of flames and superheated air. Its quick nimbleness lets it dodge attacks even while scorching an enemy.
 Generation = 2
+Flags = Starter
 Evolutions = TYPHLOSION,Level,36
 #-------------------------------
 [TYPHLOSION]
@@ -4148,6 +4164,7 @@ Habitat = Grassland
 Category = Volcano
 Pokedex = It can hide behind a shimmering heat haze that it creates using its intense flames. Typhlosion create blazing explosive blasts that burn everything to cinders.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [TOTODILE]
 Name = Totodile
@@ -4174,6 +4191,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Despite its small body, Totodile's jaws are very powerful. While it may think it is just playfully nipping, its bite has enough strength to cause serious injury.
 Generation = 2
+Flags = Starter
 Evolutions = CROCONAW,Level,18
 #-------------------------------
 [CROCONAW]
@@ -4200,6 +4218,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = Once its jaws clamp down on its foe, it will absolutely not let go. Because the tips of its fangs are forked back like fishhooks, they become irremovably embedded.
 Generation = 2
+Flags = Starter
 Evolutions = FERALIGATR,Level,30
 #-------------------------------
 [FERALIGATR]
@@ -4226,6 +4245,7 @@ Habitat = WatersEdge
 Category = Big Jaw
 Pokedex = It opens its huge mouth to intimidate enemies. In battle, it runs using its thick and powerful hind legs to charge the foe with incredible speed.
 Generation = 2
+Flags = Starter
 #-------------------------------
 [SENTRET]
 Name = Sentret
@@ -5852,6 +5872,7 @@ Category = Coral
 Pokedex = Corsola live in warm southern seas. If the sea becomes polluted, the beautiful coral stalks become discolored and crumble away in tatters.
 Generation = 2
 WildItemUncommon = LUMINOUSMOSS
+Evolutions = CURSOLA,None,
 #-------------------------------
 [REMORAID]
 Name = Remoraid
@@ -6639,6 +6660,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = It makes its nest in a giant tree in the forest. It ferociously guards against anything nearing its territory. It is said to be the protector of the trees.
 Generation = 3
+Flags = Starter
 Evolutions = GROVYLE,Level,16
 #-------------------------------
 [GROVYLE]
@@ -6665,6 +6687,7 @@ Habitat = Forest
 Category = Wood Gecko
 Pokedex = Leaves grow out of this Pokémon's body. They help obscure a Grovyle from the eyes of its enemies while it is in a thickly overgrown forest.
 Generation = 3
+Flags = Starter
 Evolutions = SCEPTILE,Level,36
 #-------------------------------
 [SCEPTILE]
@@ -6691,6 +6714,7 @@ Habitat = Forest
 Category = Forest
 Pokedex = In the jungle, its power is without equal. This Pokémon carefully grows trees and plants. It regulates its body temperature by basking in sunlight.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [TORCHIC]
 Name = Torchic
@@ -6717,6 +6741,7 @@ Habitat = Grassland
 Category = Chick
 Pokedex = If attacked, it strikes back by spitting balls of fire it forms in its stomach. A Torchic dislikes darkness because it can't see its surroundings.
 Generation = 3
+Flags = Starter
 Evolutions = COMBUSKEN,Level,16
 #-------------------------------
 [COMBUSKEN]
@@ -6743,6 +6768,7 @@ Habitat = Grassland
 Category = Young Fowl
 Pokedex = It lashes out with 10 kicks per second. Its strong fighting instinct compels it to keep up its offensive until the opponent gives up.
 Generation = 3
+Flags = Starter
 Evolutions = BLAZIKEN,Level,36
 #-------------------------------
 [BLAZIKEN]
@@ -6769,6 +6795,7 @@ Habitat = Grassland
 Category = Blaze
 Pokedex = It learns martial arts that use punches and kicks. Every several years, its old feathers burn off, and new, supple feathers grow back in their place.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [MUDKIP]
 Name = Mudkip
@@ -6795,6 +6822,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = On land, it can powerfully lift large boulders by planting its four feet and heaving. It sleeps by burying itself in soil at the water's edge.
 Generation = 3
+Flags = Starter
 Evolutions = MARSHTOMP,Level,16
 #-------------------------------
 [MARSHTOMP]
@@ -6821,6 +6849,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = Its toughened hind legs enable it to stand upright. Because it weakens if its skin dries out, it replenishes fluids by playing in mud.
 Generation = 3
+Flags = Starter
 Evolutions = SWAMPERT,Level,36
 #-------------------------------
 [SWAMPERT]
@@ -6847,6 +6876,7 @@ Habitat = WatersEdge
 Category = Mud Fish
 Pokedex = If it senses the approach of a storm and a tidal wave, it protects its seaside nest by piling up boulders. It swims as fast as a jet ski.
 Generation = 3
+Flags = Starter
 #-------------------------------
 [POOCHYENA]
 Name = Poochyena
@@ -6955,6 +6985,7 @@ Pokedex = It is exceedingly fast if it only has to run in a straight line. When 
 Generation = 3
 WildItemCommon = POTION
 WildItemUncommon = MAXREVIVE
+Evolutions = OBSTAGOON,None,
 #-------------------------------
 [WURMPLE]
 Name = Wurmple
@@ -10199,6 +10230,7 @@ Shape = Quadruped
 Category = Tiny Leaf
 Pokedex = Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.
 Generation = 4
+Flags = Starter
 Evolutions = GROTLE,Level,18
 #-------------------------------
 [GROTLE]
@@ -10224,6 +10256,7 @@ Shape = Quadruped
 Category = Grove
 Pokedex = It lives along water in forests. In the daytime, it leaves the forest to sunbathe its treed shell.
 Generation = 4
+Flags = Starter
 Evolutions = TORTERRA,Level,32
 #-------------------------------
 [TORTERRA]
@@ -10249,6 +10282,7 @@ Shape = Quadruped
 Category = Continent
 Pokedex = Small Pokémon occasionally gather on its unmoving back to begin building their nests.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [CHIMCHAR]
 Name = Chimchar
@@ -10274,6 +10308,7 @@ Shape = BipedalTail
 Category = Chimp
 Pokedex = It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps.
 Generation = 4
+Flags = Starter
 Evolutions = MONFERNO,Level,14
 #-------------------------------
 [MONFERNO]
@@ -10299,6 +10334,7 @@ Shape = BipedalTail
 Category = Playful
 Pokedex = To intimidate attackers, it stretches the fire on its tail to make itself appear bigger.
 Generation = 4
+Flags = Starter
 Evolutions = INFERNAPE,Level,36
 #-------------------------------
 [INFERNAPE]
@@ -10324,6 +10360,7 @@ Shape = BipedalTail
 Category = Flame
 Pokedex = It uses a special kind of martial arts involving all its limbs. Its fire never goes out.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [PIPLUP]
 Name = Piplup
@@ -10349,6 +10386,7 @@ Shape = Bipedal
 Category = Penguin
 Pokedex = Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.
 Generation = 4
+Flags = Starter
 Evolutions = PRINPLUP,Level,16
 #-------------------------------
 [PRINPLUP]
@@ -10374,6 +10412,7 @@ Shape = BipedalTail
 Category = Penguin
 Pokedex = It lives alone, away from others. Apparently, every one of them believes it is the most important.
 Generation = 4
+Flags = Starter
 Evolutions = EMPOLEON,Level,36
 #-------------------------------
 [EMPOLEON]
@@ -10399,6 +10438,7 @@ Shape = BipedalTail
 Category = Emperor
 Pokedex = The three horns that extend from its beak attest to its power. The leader has the biggest horns.
 Generation = 4
+Flags = Starter
 #-------------------------------
 [STARLY]
 Name = Starly
@@ -12902,6 +12942,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They photosynthesize by bathing their tails in sunlight. When they are not feeling well, their tails droop.
 Generation = 5
+Flags = Starter
 Evolutions = SERVINE,Level,17
 #-------------------------------
 [SERVINE]
@@ -12927,6 +12968,7 @@ Shape = BipedalTail
 Category = Grass Snake
 Pokedex = They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.
 Generation = 5
+Flags = Starter
 Evolutions = SERPERIOR,Level,36
 #-------------------------------
 [SERPERIOR]
@@ -12952,6 +12994,7 @@ Shape = Serpentine
 Category = Regal
 Pokedex = They raise their heads to intimidate opponents, but only give it their all when fighting a powerful opponent.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [TEPIG]
 Name = Tepig
@@ -12977,6 +13020,7 @@ Shape = Quadruped
 Category = Fire Pig
 Pokedex = It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.
 Generation = 5
+Flags = Starter
 Evolutions = PIGNITE,Level,17
 #-------------------------------
 [PIGNITE]
@@ -13002,6 +13046,7 @@ Shape = BipedalTail
 Category = Fire Pig
 Pokedex = Whatever it eats becomes fuel for the flame in its stomach. When it is angered, the intensity of the flame increases.
 Generation = 5
+Flags = Starter
 Evolutions = EMBOAR,Level,36
 #-------------------------------
 [EMBOAR]
@@ -13027,6 +13072,7 @@ Shape = BipedalTail
 Category = Mega Fire Pig
 Pokedex = It can throw a fire punch by setting its fists on fire with its fiery chin. It cares deeply about its friends.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [OSHAWOTT]
 Name = Oshawott
@@ -13052,6 +13098,7 @@ Shape = BipedalTail
 Category = Sea Otter
 Pokedex = The scalchop on its stomach is made from the same elements as claws. It detaches the scalchop for use as a blade.
 Generation = 5
+Flags = Starter
 Evolutions = DEWOTT,Level,17
 #-------------------------------
 [DEWOTT]
@@ -13077,6 +13124,7 @@ Shape = BipedalTail
 Category = Discipline
 Pokedex = Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.
 Generation = 5
+Flags = Starter
 Evolutions = SAMUROTT,Level,36
 #-------------------------------
 [SAMUROTT]
@@ -13102,6 +13150,7 @@ Shape = Quadruped
 Category = Formidable
 Pokedex = Part of the armor on its anterior legs becomes a giant sword. Its cry alone is enough to intimidate most enemies.
 Generation = 5
+Flags = Starter
 #-------------------------------
 [PATRAT]
 Name = Patrat
@@ -14607,7 +14656,7 @@ Category = Spirit
 Pokedex = These Pokémon arose from the spirits of people interred in graves in past ages. Each retains memories of its former life.
 Generation = 5
 WildItemUncommon = SPELLTAG
-Evolutions = COFAGRIGUS,Level,34
+Evolutions = COFAGRIGUS,Level,34,RUNERIGUS,None,
 #-------------------------------
 [COFAGRIGUS]
 Name = Cofagrigus
@@ -16800,6 +16849,7 @@ Shape = BipedalTail
 Category = Spiny Nut
 Pokedex = The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.
 Generation = 6
+Flags = Starter
 Evolutions = QUILLADIN,Level,16
 #-------------------------------
 [QUILLADIN]
@@ -16825,6 +16875,7 @@ Shape = BipedalTail
 Category = Spiny Armor
 Pokedex = They strengthen their lower bodies by running into one another. They are very kind and won't start fights.
 Generation = 6
+Flags = Starter
 Evolutions = CHESNAUGHT,Level,36
 #-------------------------------
 [CHESNAUGHT]
@@ -16850,6 +16901,7 @@ Shape = BipedalTail
 Category = Spiny Armor
 Pokedex = Its Tackle is forceful enough to flip a 50-ton tank. It shields its allies from danger with its own body.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [FENNEKIN]
 Name = Fennekin
@@ -16875,6 +16927,7 @@ Shape = Quadruped
 Category = Fox
 Pokedex = As it walks, it munches on a twig in place of a snack. It intimidates opponents by puffing hot air out of its ears.
 Generation = 6
+Flags = Starter
 Evolutions = BRAIXEN,Level,16
 #-------------------------------
 [BRAIXEN]
@@ -16900,6 +16953,7 @@ Shape = BipedalTail
 Category = Fox
 Pokedex = When the twig is plucked from its tail, friction sets the twig alight. The flame is used to send signals to its allies.
 Generation = 6
+Flags = Starter
 Evolutions = DELPHOX,Level,36
 #-------------------------------
 [DELPHOX]
@@ -16925,6 +16979,7 @@ Shape = BipedalTail
 Category = Fox
 Pokedex = It gazes into the flame at the tip of its branch to achieve a focused state, which allows it to see into the future.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [FROAKIE]
 Name = Froakie
@@ -16950,6 +17005,7 @@ Shape = Quadruped
 Category = Bubble Frog
 Pokedex = It protects its skin by covering its body in delicate bubbles. Beneath its happy-go-lucky air, it keeps a watchful eye on its surroundings.
 Generation = 6
+Flags = Starter
 Evolutions = FROGADIER,Level,16
 #-------------------------------
 [FROGADIER]
@@ -16975,6 +17031,7 @@ Shape = Bipedal
 Category = Bubble Frog
 Pokedex = It can throw bubble-covered pebbles with precise control, hitting empty cans up to a hundred feet away.
 Generation = 6
+Flags = Starter
 Evolutions = GRENINJA,Level,36
 #-------------------------------
 [GRENINJA]
@@ -17000,6 +17057,7 @@ Shape = Bipedal
 Category = Ninja
 Pokedex = It appears and vanishes with a ninja’s grace. It toys with its enemies using swift movements, while slicing them with throwing stars of sharpest water.
 Generation = 6
+Flags = Starter
 #-------------------------------
 [BUNNELBY]
 Name = Bunnelby
@@ -18600,6 +18658,7 @@ Shape = Winged
 Category = Grass Quill
 Pokedex = It sends its feathers, which are as sharp as blades, flying in attack. Its legs are strong, so its kicks are also formidable.
 Generation = 7
+Flags = Starter
 Evolutions = DARTRIX,Level,17
 #-------------------------------
 [DARTRIX]
@@ -18625,6 +18684,7 @@ Shape = Winged
 Category = Blade Quill
 Pokedex = A bit of a dandy, it spends its free time preening its wings. Its preoccupation with any dirt on its plumage can leave it unable to battle.
 Generation = 7
+Flags = Starter
 Evolutions = DECIDUEYE,Level,34
 #-------------------------------
 [DECIDUEYE]
@@ -18650,6 +18710,7 @@ Shape = Winged
 Category = Arrow Quill
 Pokedex = It fires arrow quills from its wings with such precision, they can pierce a pebble at distances over a hundred yards.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [LITTEN]
 Name = Litten
@@ -18675,6 +18736,7 @@ Shape = Quadruped
 Category = Fire Cat
 Pokedex = Its coat regrows twice a year. When the time comes, Litten sets its own body on fire and burns away the old fur.
 Generation = 7
+Flags = Starter
 Evolutions = TORRACAT,Level,17
 #-------------------------------
 [TORRACAT]
@@ -18700,6 +18762,7 @@ Shape = Quadruped
 Category = Fire Cat
 Pokedex = It can act spoiled if it grows close to its Trainer. A powerful Pokémon, its sharp claws can leave its Trainer's whole body covered in scratches.
 Generation = 7
+Flags = Starter
 Evolutions = INCINEROAR,Level,34
 #-------------------------------
 [INCINEROAR]
@@ -18725,6 +18788,7 @@ Shape = BipedalTail
 Category = Heel
 Pokedex = Although it's rough mannered and egotistical, it finds beating down unworthy opponents boring. It gets motivated for stronger opponents.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [POPPLIO]
 Name = Popplio
@@ -18750,6 +18814,7 @@ Shape = Finned
 Category = Sea Lion
 Pokedex = This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.
 Generation = 7
+Flags = Starter
 Evolutions = BRIONNE,Level,17
 #-------------------------------
 [BRIONNE]
@@ -18775,6 +18840,7 @@ Shape = Finned
 Category = Pop Star
 Pokedex = It gets excited when it sees a dance it doesn't know. This hard worker practices diligently until it can learn that dance.
 Generation = 7
+Flags = Starter
 Evolutions = PRIMARINA,Level,34
 #-------------------------------
 [PRIMARINA]
@@ -18800,6 +18866,7 @@ Shape = Finned
 Category = Soloist
 Pokedex = It controls its water balloons with song. The melody is learned from others of its kind and is passed down from one generation to the next.
 Generation = 7
+Flags = Starter
 #-------------------------------
 [PIKIPEK]
 Name = Pikipek
@@ -20798,6 +20865,7 @@ Shape = BipedalTail
 Category = Chimp
 Pokedex = When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.
 Generation = 8
+Flags = Starter
 Evolutions = THWACKEY,Level,16
 #-------------------------------
 [THWACKEY]
@@ -20823,6 +20891,7 @@ Shape = BipedalTail
 Category = Beat
 Pokedex = When it's drumming out rapid beats in battle, it gets so caught up in the rhythm that it won't even notice that it's already knocked out its opponent.
 Generation = 8
+Flags = Starter
 Evolutions = RILLABOOM,Level,35
 #-------------------------------
 [RILLABOOM]
@@ -20848,6 +20917,7 @@ Shape = Bipedal
 Category = Drummer
 Pokedex = By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle.
 Generation = 8
+Flags = Starter
 #-------------------------------
 [SCORBUNNY]
 Name = Scorbunny
@@ -20873,6 +20943,7 @@ Shape = BipedalTail
 Category = Rabbit
 Pokedex = A warm-up of running around gets fire energy coursing through this Pokémon's body. Once that happens, it's ready to fight at full power.
 Generation = 8
+Flags = Starter
 Evolutions = RABOOT,Level,16
 #-------------------------------
 [RABOOT]
@@ -20898,6 +20969,7 @@ Shape = BipedalTail
 Category = Rabbit
 Pokedex = It kicks berries right off the branches of trees and then juggles them with its feet, practicing its footwork.
 Generation = 8
+Flags = Starter
 Evolutions = CINDERACE,Level,35
 #-------------------------------
 [CINDERACE]
@@ -20923,6 +20995,7 @@ Shape = BipedalTail
 Category = Striker
 Pokedex = It juggles a pebble with its feet, turning it into a burning soccer ball. Its shots strike opponents hard and leave them scorched.
 Generation = 8
+Flags = Starter
 #-------------------------------
 [SOBBLE]
 Name = Sobble
@@ -20948,6 +21021,7 @@ Shape = Quadruped
 Category = Water Lizard
 Pokedex = When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping.
 Generation = 8
+Flags = Starter
 Evolutions = DRIZZILE,Level,16
 #-------------------------------
 [DRIZZILE]
@@ -20973,6 +21047,7 @@ Shape = BipedalTail
 Category = Water Lizard
 Pokedex = A clever combatant, this Pokémon battles using water balloons created with moisture secreted from its palms.
 Generation = 8
+Flags = Starter
 Evolutions = INTELEON,Level,35
 #-------------------------------
 [INTELEON]
@@ -20998,6 +21073,7 @@ Shape = BipedalTail
 Category = Secret Agent
 Pokedex = It has many hidden capabilities, such as fingertips that can shoot water and a membrane on its back that it can use to glide through the air.
 Generation = 8
+Flags = Starter
 #-------------------------------
 [SKWOVET]
 Name = Skwovet


### PR DESCRIPTION
Added new flags for various species:
- Add flag `Starter` to all starter Pokemon and their evolutions.
- Add flag `Legendary` to all legendary Pokemon (as listed on Bulbapedia)
- Add flag `Mythical` to all mythical Pokemon (as listed on Bulbapedia)

I was also thinking of adding `Alolan` and `Galarian` flags to the approriate regional forms, but I don't know if that's necessary.
I was also planning to add new metadata entries called `WildLegendaryBattleBGM` and `WildLegendaryVictoryME`, but I would like to confirm if we still plan on adding the `BattleBGM` property to `pokemon.txt`, because if that's the case then it'd make these metadata property redundant.