### PR TITLE
Cursor text entry tab auto-switch

### DIFF
--- a/Data/Scripts/016_UI/024_UI_TextEntry.rb
+++ b/Data/Scripts/016_UI/024_UI_TextEntry.rb
@@ -731,6 +731,8 @@ class PokemonEntryScene2
             @sprites["cursor"].setCursorPos(@cursorpos)
           end
           pbUpdateOverlay
+          # Auto-switch to lowercase letters after the first uppercase letter is selected
+          pbChangeTab(1) if @mode == 0 && @helper.cursor == 1
         end
       end
     end


### PR DESCRIPTION
This PR adds a small line to the cursor text entry screen to switch to the lowercase letters tab after the first letter is selected, and that letter is is an uppercase letter. This is a small QOL change that has been present in the latest games from Gen 6  onwards, and makes the cursor text entry screen a little less cumbersome to type.