### PR TITLE
Bugfixes

### DIFF
--- a/Data/Scripts/007_Objects and windows/009_Planes.rb
+++ b/Data/Scripts/007_Objects and windows/009_Planes.rb
@@ -49,10 +49,12 @@ class AnimatedPlane < Plane
   end
 
   def set_panorama(file, hue = 0)
+    return clear_bitmap if file.nil?
     setBitmap("Graphics/Panoramas/" + file, hue)
   end
 
   def set_fog(file, hue = 0)
+    return clear_bitmap if file.nil?
     setBitmap("Graphics/Fogs/" + file, hue)
   end
 

--- a/Data/Scripts/007_Objects and windows/009_Planes.rb
+++ b/Data/Scripts/007_Objects and windows/009_Planes.rb
@@ -49,13 +49,19 @@ class AnimatedPlane < Plane
   end
 
   def set_panorama(file, hue = 0)
-    return clear_bitmap if file.nil?
-    setBitmap("Graphics/Panoramas/" + file, hue)
+    if file.is_a?(String) && file.length > 0
+      setBitmap("Graphics/Panoramas/" + file, hue)
+    else
+      clear_bitmap
+    end
   end
 
   def set_fog(file, hue = 0)
-    return clear_bitmap if file.nil?
-    setBitmap("Graphics/Fogs/" + file, hue)
+    if file.is_a?(String) && file.length > 0
+      setBitmap("Graphics/Fogs/" + file, hue)
+    else
+      clear_bitmap
+    end
   end
 
   private

--- a/Data/Scripts/011_Battle/002_Battler/002_Battler_Initialize.rb
+++ b/Data/Scripts/011_Battle/002_Battler/002_Battler_Initialize.rb
@@ -105,13 +105,7 @@ class Battle::Battler
       @effects[PBEffects::GastroAcid]  = false if unstoppableAbility?
     else
       # These effects are passed on if Baton Pass is used
-      @stages[:ATTACK]          = 0
-      @stages[:DEFENSE]         = 0
-      @stages[:SPEED]           = 0
-      @stages[:SPECIAL_ATTACK]  = 0
-      @stages[:SPECIAL_DEFENSE] = 0
-      @stages[:ACCURACY]        = 0
-      @stages[:EVASION]         = 0
+      GameData::Stat.each_battle { |stat| @stages[stat.id] = 0 }
       @effects[PBEffects::AquaRing]          = false
       @effects[PBEffects::Confusion]         = 0
       @effects[PBEffects::Curse]             = false

--- a/Data/Scripts/012_Overworld/005_Overworld_Fishing.rb
+++ b/Data/Scripts/012_Overworld/005_Overworld_Fishing.rb
@@ -14,13 +14,11 @@ def pbFishingBegin
         pbUpdateSceneMap
       end
     end
-    $game_player.lock_pattern = false
   end
 end
 
 def pbFishingEnd
   if !pbCommonEvent(Settings::FISHING_END_COMMON_EVENT)
-    $game_player.lock_pattern = true
     4.times do |pattern|
       $game_player.pattern = pattern
       (Graphics.frame_rate / 20).times do


### PR DESCRIPTION
- Fixed new battle stats not being added to `@stages` for battlers
- Fixed crash when setting fogs or panoramas to `(None)` using the `Change Map Settings...` event command
- Fixed fishing animation looping through its frames multiple times (and looping infinitely when surfing).