### PR TITLE
Fixed typo in "CannotMetronome"

### DIFF
--- a/Data/Scripts/011_Battle/003_Move/011_MoveEffects_Items.rb
+++ b/Data/Scripts/011_Battle/003_Move/011_MoveEffects_Items.rb
@@ -245,7 +245,7 @@ class Battle::Move::CorrodeTargetItem < Battle::Move
 end
 
 #===============================================================================
-# For 5 rounds, the target cannnot use its held item, its held item has no
+# For 5 rounds, the target cannot use its held item, its held item has no
 # effect, and no items can be used on it. (Embargo)
 #===============================================================================
 class Battle::Move::StartTargetCannotUseItem < Battle::Move

--- a/Data/Scripts/011_Battle/003_Move/012_MoveEffects_ChangeMoveEffect.rb
+++ b/Data/Scripts/011_Battle/003_Move/012_MoveEffects_ChangeMoveEffect.rb
@@ -960,7 +960,7 @@ class Battle::Move::UseRandomMove < Battle::Move
       move_id = move_keys[@battle.pbRandom(move_keys.length)]
       move_data = GameData::Move.get(move_id)
       next if @moveBlacklist.include?(move_data.function_code)
-      next if move_data.has_flag?("CannnotMetronome")
+      next if move_data.has_flag?("CannotMetronome")
       next if move_data.type == :SHADOW
       @metronomeMove = move_data.id
       break


### PR DESCRIPTION
This flag had 3 N's in its name where it was supposed to be two. In the move PBS files, the flag is spelled correctly.