### PR TITLE
Display version number of plugins in the console

### DIFF
--- a/Data/Scripts/001_Technical/005_PluginManager.rb
+++ b/Data/Scripts/001_Technical/005_PluginManager.rb
@@ -710,7 +710,10 @@ module PluginManager
         # try to run the code
         begin
           eval(code, TOPLEVEL_BINDING, fname)
-          Console.echoln_li "Loaded plugin: '#{name}'" if !echoed_plugins.include?(name)
+          next if echoed_plugins.include?(name)
+          name_str    = Console.markup_style(name, text: :light_red)
+          version_str = Console.markup_style("v#{meta[:version]}", text: :purple)
+          Console.echoln_li "Loaded plugin: #{name_str} #{version_str}"
           echoed_plugins.push(name)
         rescue Exception   # format error message to display
           self.pluginErrorMsg(name, sname)

--- a/Data/Scripts/001_Technical/005_PluginManager.rb
+++ b/Data/Scripts/001_Technical/005_PluginManager.rb
@@ -710,10 +710,7 @@ module PluginManager
         # try to run the code
         begin
           eval(code, TOPLEVEL_BINDING, fname)
-          next if echoed_plugins.include?(name)
-          name_str    = Console.markup_style(name, text: :light_red)
-          version_str = Console.markup_style("v#{meta[:version]}", text: :purple)
-          Console.echoln_li "Loaded plugin: #{name_str} #{version_str}"
+          Console.echoln_li "Loaded plugin: '#{name}' (ver. #{meta[:version]})" if !echoed_plugins.include?(name)
           echoed_plugins.push(name)
         rescue Exception   # format error message to display
           self.pluginErrorMsg(name, sname)


### PR DESCRIPTION
This PR edits the echoed line `Loaded Plugin: *plugin name*` to  display the version number of the plugin along with the name. This would be very useful for plugin makers to debug issues with their plugins, because some users don't update their plugins on time and not every plugin is displayed in `Essentials::ERROR_TEXT`.