### PR TITLE
Show a Pokémon's Dex Entry upon obtaining it, including an option

### DIFF
--- a/Data/Scripts/011_Battle/004_Scene/003_Scene_ChooseCommands.rb
+++ b/Data/Scripts/011_Battle/004_Scene/003_Scene_ChooseCommands.rb
@@ -452,15 +452,4 @@ class Battle::Scene
   def pbNameEntry(helpText, pkmn)
     return pbEnterPokemonName(helpText, 0, Pokemon::MAX_NAME_SIZE, "", pkmn)
   end
-
-  #=============================================================================
-  # Shows the Pokédex entry screen for a newly caught Pokémon
-  #=============================================================================
-  def pbShowPokedex(species)
-    pbFadeOutIn {
-      scene = PokemonPokedexInfo_Scene.new
-      screen = PokemonPokedexInfoScreen.new(scene)
-      screen.pbDexEntry(species)
-    }
-  end
 end

--- a/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
+++ b/Data/Scripts/011_Battle/006_Other battle code/005_Battle_CatchAndStoreMixin.rb
@@ -34,7 +34,7 @@ module Battle::CatchAndStoreMixin
         if $player.has_pokedex
           pbDisplayPaused(_INTL("{1}'s data was added to the Pokédex.", pkmn.name))
           pbPlayer.pokedex.register_last_seen(pkmn)
-          @scene.pbShowPokedex(pkmn.species)
+          @scene.pbShowPokedex(pkmn,false)
         end
       end
       # Record a Shadow Pokémon's species as having been caught

--- a/Data/Scripts/012_Overworld/001_Overworld.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld.rb
@@ -820,3 +820,26 @@ def pbBuyPrize(item, quantity = 1)
                   item_name, pocket, PokemonBag.pocket_names[pocket - 1]))
   return true
 end
+
+#===============================================================================
+# Shows the Pokédex entry screen for a Pokémon
+#===============================================================================
+def pbShowPokedex(pkmn,message=true,owned=true,forced=false)
+  species = pkmn.species
+  if $PokemonSystem.showdexentry>0 && !forced
+    $player.pokedex.register(pkmn)
+    $player.pokedex.set_owned(species) if owned
+    return true
+  end
+  pbMessage(_INTL("{1}'s data was added to the Pokédex.",GameData::Species.try_get(species).real_name)) if message
+  if !$player.owned?(species)
+    $player.pokedex.register(pkmn)
+    $player.pokedex.set_owned(species) if owned
+    pbFadeOutIn {
+      scene = PokemonPokedexInfo_Scene.new
+      screen = PokemonPokedexInfoScreen.new(scene)
+      screen.pbDexEntry(species)
+    }
+  end
+  return true
+end

--- a/Data/Scripts/016_UI/001_Non-interactive UI/003_UI_EggHatching.rb
+++ b/Data/Scripts/016_UI/001_Non-interactive UI/003_UI_EggHatching.rb
@@ -102,7 +102,8 @@ class PokemonEggHatch_Scene
     pbBGMStop
     pbMEPlay("Evolution success")
     @pokemon.name = nil
-    pbMessage(_INTL("\\se[]{1} hatched from the Egg!\\wt[80]", @pokemon.name)) { update }
+    # Show dex entry
+    pbShowPokedex(@pokemon)
     if $PokemonSystem.givenicknames == 0 &&
        pbConfirmMessage(
          _INTL("Would you like to nickname the newly hatched {1}?", @pokemon.name)
@@ -199,8 +200,6 @@ def pbHatch(pokemon)
   pokemon.timeEggHatched = pbGetTimeNow
   pokemon.obtain_method  = 1   # hatched from egg
   pokemon.hatched_map    = $game_map.map_id
-  $player.pokedex.register(pokemon)
-  $player.pokedex.set_owned(pokemon.species)
   $player.pokedex.set_seen_egg(pokemon.species)
   pokemon.record_first_moves
   if !pbHatchAnimation(pokemon)
@@ -208,6 +207,7 @@ def pbHatch(pokemon)
     pbMessage(_INTL("...\1"))
     pbMessage(_INTL("... .... .....\1"))
     pbMessage(_INTL("{1} hatched from the Egg!", speciesname))
+    pbShowPokedex(pokemon)
     if $PokemonSystem.givenicknames == 0 &&
        pbConfirmMessage(_INTL("Would you like to nickname the newly hatched {1}?", speciesname))
       nickname = pbEnterPokemonName(_INTL("{1}'s nickname?", speciesname),

--- a/Data/Scripts/016_UI/001_Non-interactive UI/004_UI_Evolution.rb
+++ b/Data/Scripts/016_UI/001_Non-interactive UI/004_UI_Evolution.rb
@@ -599,9 +599,8 @@ class PokemonEvolutionScene
     @pokemon.form    = 0 if @pokemon.isSpecies?(:MOTHIM)
     @pokemon.calc_stats
     @pokemon.ready_to_evolve = false
-    # See and own evolved species
-    $player.pokedex.register(@pokemon)
-    $player.pokedex.set_owned(@newspecies)
+    # See the Pokédex entry
+    pbShowPokedex(@pokemon)
     # Learn moves upon evolution for evolved species
     movelist = @pokemon.getMoveList
     movelist.each do |i|

--- a/Data/Scripts/016_UI/001_Non-interactive UI/005_UI_Trading.rb
+++ b/Data/Scripts/016_UI/001_Non-interactive UI/005_UI_Trading.rb
@@ -185,6 +185,8 @@ class PokemonTrade_Scene
     pbMessageDisplay(@sprites["msgwindow"],
                      _ISPRINTF("{1:s}\r\nID: {2:05d}   OT: {3:s}\1",
                                @pokemon2.name, @pokemon2.owner.public_id, @pokemon2.owner.name)) { pbUpdate }
+    # See the Pokédex entry
+    pbShowPokedex(@pokemon2,false)
     pbMessageDisplay(@sprites["msgwindow"],
                      _INTL("Take good care of {1}.", speciesname2)) { pbUpdate }
   end
@@ -212,8 +214,6 @@ def pbStartTrade(pokemonIndex, newpoke, nickname, trainerName, trainerGender = 0
   yourPokemon.obtain_method = 2   # traded
   yourPokemon.reset_moves if resetmoves
   yourPokemon.record_first_moves
-  $player.pokedex.register(yourPokemon)
-  $player.pokedex.set_owned(yourPokemon.species)
   pbFadeOutInWithMusic {
     evo = PokemonTrade_Scene.new
     evo.pbStartScreen(myPokemon, yourPokemon, $player.name, trainerName)

--- a/Data/Scripts/016_UI/015_UI_Options.rb
+++ b/Data/Scripts/016_UI/015_UI_Options.rb
@@ -14,6 +14,7 @@ class PokemonSystem
   attr_accessor :bgmvolume
   attr_accessor :sevolume
   attr_accessor :textinput
+  attr_accessor :showdexentry
 
   def initialize
     @textspeed     = 1     # Text speed (0=slow, 1=normal, 2=fast)
@@ -28,6 +29,7 @@ class PokemonSystem
     @bgmvolume     = 100   # Volume of background music and ME
     @sevolume      = 100   # Volume of sound effects
     @textinput     = 0     # Text input mode (0=cursor, 1=keyboard)
+    @showdexentry  = 0     # Shows the dex entry when receiving a new Pokemon (0=on, 1=off)
   end
 end
 
@@ -528,4 +530,14 @@ MenuHandlers.add(:options_menu, :screen_size, {
     $PokemonSystem.screensize = value
     pbSetResizeFactor($PokemonSystem.screensize)
   }
+})
+
+MenuHandlers.add(:options_menu, :show_dex_entry, {
+  "name"        => _INTL("Show Dex Entry"),
+  "order"       => 120,
+  "type"        => EnumOption,
+  "parameters"  => [_INTL("On"), _INTL("Off")],
+  "description" => _INTL("Choose whether you wish to see dex entries of newly obtained Pokémon."),
+  "get_proc"    => proc { next $PokemonSystem.showdexentry },
+  "set_proc"    => proc { |value, _scene| $PokemonSystem.showdexentry = value }
 })

--- a/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
+++ b/Data/Scripts/019_Utilities/002_Utilities_Pokemon.rb
@@ -36,8 +36,7 @@ def pbNicknameAndStore(pkmn)
     pbMessage(_INTL("The Pokémon Boxes are full and can't accept any more!"))
     return
   end
-  $player.pokedex.set_seen(pkmn.species)
-  $player.pokedex.set_owned(pkmn.species)
+  pbShowPokedex(pkmn)
   pbNickname(pkmn)
   pbStorePokemon(pkmn)
 end
@@ -111,9 +110,8 @@ def pbAddForeignPokemon(pkmn, level = 1, owner_name = nil, nickname = nil, owner
   else
     pbMessage(_INTL("\\me[Pkmn get]{1} received a Pokémon.\1", $player.name))
   end
+  pbShowPokedex(pkmn)
   pbStorePokemon(pkmn)
-  $player.pokedex.register(pkmn) if see_form
-  $player.pokedex.set_owned(pkmn.species)
   return true
 end
 


### PR DESCRIPTION
Show a Pokémon’s Pokédex entry on more occasions. Make a Setting/Options screen option/both for this.
- After hatching.
- After evolution.
- After trading.
- Upon being given a new Pokémon