### PR TITLE
Fix challenge min length

### DIFF
--- a/Data/Scripts/018_Alternate battle modes/002_Battle Frontier rules/002_Challenge_Rulesets.rb
+++ b/Data/Scripts/018_Alternate battle modes/002_Battle Frontier rules/002_Challenge_Rulesets.rb
@@ -148,7 +148,7 @@ class PokemonRuleSet
   def canRegisterTeam?(team)
     return false if !team || team.length < self.minTeamLength
     return false if team.length > self.maxTeamLength
-    teamNumber = [self.maxLength, team.length].min
+    teamNumber = self.minTeamLength
     team.each do |pkmn|
       return false if !isPokemonValid?(pkmn)
     end
@@ -175,14 +175,14 @@ class PokemonRuleSet
   # team rules and subset rules. Not all Pokemon in the team have to be valid.
   def hasValidTeam?(team)
     return false if !team || team.length < self.minTeamLength
-    teamNumber = [self.maxLength, team.length].min
+    teamNumber = self.minTeamLength
     validPokemon = []
     team.each do |pkmn|
       validPokemon.push(pkmn) if isPokemonValid?(pkmn)
     end
-    return false if validPokemon.length < self.minLength
+    return false if validPokemon.length < teamNumber
     if @teamRules.length > 0
-      pbEachCombination(team, self.minLength) { |comb| return true if isValid?(comb) }
+      pbEachCombination(team, teamNumber) { |comb| return true if isValid?(comb) }
       return false
     end
     return true

--- a/Data/Scripts/018_Alternate battle modes/002_Battle Frontier rules/002_Challenge_Rulesets.rb
+++ b/Data/Scripts/018_Alternate battle modes/002_Battle Frontier rules/002_Challenge_Rulesets.rb
@@ -180,9 +180,9 @@ class PokemonRuleSet
     team.each do |pkmn|
       validPokemon.push(pkmn) if isPokemonValid?(pkmn)
     end
-    return false if validPokemon.length < teamNumber
+    return false if validPokemon.length < self.minLength
     if @teamRules.length > 0
-      pbEachCombination(team, teamNumber) { |comb| return true if isValid?(comb) }
+      pbEachCombination(team, self.minLength) { |comb| return true if isValid?(comb) }
       return false
     end
     return true


### PR DESCRIPTION
Challenge min pokémon, combined with team/pokémon rules aren't working properly.

You can reproduce adding the below code, having the demo party and calling setRule.
```
def pbSomeRules
  ret = PokemonChallengeRules.new 
  ret.addTeamRule(SpeciesClause.new)
  ret.addPokemonRule(HeightRestriction.new(1))
  ret.ruleset.setNumberRange(1,6)
  return ret
end

def setRule 
  pbBattleChallenge.set("someChallenge",7,pbSomeRules)
  pbBattleChallenge.start
  print pbHasEligible?
end
```
In this scenario you have 2 pokémon eligible, but the script returns false, since it requires the max (6) to be eligible.