### PR TITLE
Removed more instances of _INTL being used in filenames

### DIFF
--- a/Data/Scripts/011_Battle/004_Scene/005_Battle_Scene_Menus.rb
+++ b/Data/Scripts/011_Battle/004_Scene/005_Battle_Scene_Menus.rb
@@ -131,7 +131,7 @@ class Battle::Scene::CommandMenu < Battle::Scene::MenuBase
       background.setBitmap("Graphics/Pictures/Battle/overlay_command")
       addSprite("background", background)
       # Create bitmaps
-      @buttonBitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/Battle/cursor_command"))
+      @buttonBitmap = AnimatedBitmap.new("Graphics/Pictures/Battle/cursor_command")
       # Create action buttons
       @buttons = Array.new(4) do |i|   # 4 command options, therefore 4 buttons
         button = SpriteWrapper.new(viewport)
@@ -231,10 +231,10 @@ class Battle::Scene::FightMenu < Battle::Scene::MenuBase
     #       0=don't show, 1=show unpressed, 2=show pressed
     if USE_GRAPHICS
       # Create bitmaps
-      @buttonBitmap  = AnimatedBitmap.new(_INTL("Graphics/Pictures/Battle/cursor_fight"))
-      @typeBitmap    = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
-      @megaEvoBitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/Battle/cursor_mega"))
-      @shiftBitmap   = AnimatedBitmap.new(_INTL("Graphics/Pictures/Battle/cursor_shift"))
+      @buttonBitmap  = AnimatedBitmap.new("Graphics/Pictures/Battle/cursor_fight")
+      @typeBitmap    = AnimatedBitmap.new("Graphics/Pictures/types")
+      @megaEvoBitmap = AnimatedBitmap.new("Graphics/Pictures/Battle/cursor_mega")
+      @shiftBitmap   = AnimatedBitmap.new("Graphics/Pictures/Battle/cursor_shift")
       # Create background graphic
       background = IconSprite.new(0, Graphics.height - 96, viewport)
       background.setBitmap("Graphics/Pictures/Battle/overlay_fight")

--- a/Data/Scripts/016_UI/002_UI_Pokedex_Menu.rb
+++ b/Data/Scripts/016_UI/002_UI_Pokedex_Menu.rb
@@ -46,7 +46,7 @@ class PokemonPokedexMenu_Scene
     @viewport.z = 99999
     @sprites = {}
     @sprites["background"] = IconSprite.new(0, 0, @viewport)
-    @sprites["background"].setBitmap(_INTL("Graphics/Pictures/Pokedex/bg_menu"))
+    @sprites["background"].setBitmap("Graphics/Pictures/Pokedex/bg_menu")
     @sprites["headings"] = Window_AdvancedTextPokemon.newWithSize(
       _INTL("<c3=F8F8F8,C02028>SEEN<r>OBTAINED</c3>"), 286, 136, 208, 64, @viewport
     )

--- a/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
+++ b/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
@@ -259,11 +259,11 @@ class PokemonPokedex_Scene
 
   def pbStartScene
     @sliderbitmap       = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_slider")
-    @typebitmap         = AnimatedBitmap.new(_INTL("Graphics/Pictures/Pokedex/icon_types"))
+    @typebitmap         = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_types")
     @shapebitmap        = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_shapes")
     @hwbitmap           = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_hw")
     @selbitmap          = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_searchsel")
-    @searchsliderbitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/Pokedex/icon_searchslider"))
+    @searchsliderbitmap = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_searchslider")
     @sprites = {}
     @viewport = Viewport.new(0, 0, Graphics.width, Graphics.height)
     @viewport.z = 99999

--- a/Data/Scripts/016_UI/004_UI_Pokedex_Entry.rb
+++ b/Data/Scripts/016_UI/004_UI_Pokedex_Entry.rb
@@ -10,7 +10,7 @@ class PokemonPokedexInfo_Scene
     @region  = region
     @page = 1
     @show_battled_count = false
-    @typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/Pokedex/icon_types"))
+    @typebitmap = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_types")
     @sprites = {}
     @sprites["background"] = IconSprite.new(0, 0, @viewport)
     @sprites["infosprite"] = PokemonSprite.new(@viewport)
@@ -94,7 +94,7 @@ class PokemonPokedexInfo_Scene
     @index   = 0
     @page = 1
     @brief = true
-    @typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/Pokedex/icon_types"))
+    @typebitmap = AnimatedBitmap.new("Graphics/Pictures/Pokedex/icon_types")
     @sprites = {}
     @sprites["background"] = IconSprite.new(0, 0, @viewport)
     @sprites["infosprite"] = PokemonSprite.new(@viewport)
@@ -198,13 +198,13 @@ class PokemonPokedexInfo_Scene
   end
 
   def drawPageInfo
-    @sprites["background"].setBitmap(_INTL("Graphics/Pictures/Pokedex/bg_info"))
+    @sprites["background"].setBitmap("Graphics/Pictures/Pokedex/bg_info")
     overlay = @sprites["overlay"].bitmap
     base   = Color.new(88, 88, 80)
     shadow = Color.new(168, 184, 184)
     imagepos = []
     if @brief
-      imagepos.push([_INTL("Graphics/Pictures/Pokedex/overlay_info"), 0, 0])
+      imagepos.push(["Graphics/Pictures/Pokedex/overlay_info", 0, 0])
     end
     species_data = GameData::Species.get_species_form(@species, @form)
     # Write various bits of text
@@ -333,7 +333,7 @@ class PokemonPokedexInfo_Scene
   end
 
   def drawPageArea
-    @sprites["background"].setBitmap(_INTL("Graphics/Pictures/Pokedex/bg_area"))
+    @sprites["background"].setBitmap("Graphics/Pictures/Pokedex/bg_area")
     overlay = @sprites["overlay"].bitmap
     base   = Color.new(88, 88, 80)
     shadow = Color.new(168, 184, 184)
@@ -382,7 +382,7 @@ class PokemonPokedexInfo_Scene
   end
 
   def drawPageForms
-    @sprites["background"].setBitmap(_INTL("Graphics/Pictures/Pokedex/bg_forms"))
+    @sprites["background"].setBitmap("Graphics/Pictures/Pokedex/bg_forms")
     overlay = @sprites["overlay"].bitmap
     base   = Color.new(88, 88, 80)
     shadow = Color.new(168, 184, 184)

--- a/Data/Scripts/016_UI/005_UI_Party.rb
+++ b/Data/Scripts/016_UI/005_UI_Party.rb
@@ -221,7 +221,7 @@ class PokemonPartyPanel < SpriteWrapper
     @overlaysprite.z = self.z + 4
     pbSetSystemFont(@overlaysprite.bitmap)
     @hpbar    = AnimatedBitmap.new("Graphics/Pictures/Party/overlay_hp")
-    @statuses = AnimatedBitmap.new(_INTL("Graphics/Pictures/statuses"))
+    @statuses = AnimatedBitmap.new("Graphics/Pictures/statuses")
     @selected      = false
     @preselected   = false
     @switching     = false

--- a/Data/Scripts/016_UI/006_UI_Summary.rb
+++ b/Data/Scripts/016_UI/006_UI_Summary.rb
@@ -117,7 +117,7 @@ class PokemonSummary_Scene
     @pokemon    = @party[@partyindex]
     @inbattle   = inbattle
     @page = 1
-    @typebitmap    = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
+    @typebitmap    = AnimatedBitmap.new("Graphics/Pictures/types")
     @markingbitmap = AnimatedBitmap.new("Graphics/Pictures/Summary/markings")
     @sprites = {}
     @sprites["background"] = IconSprite.new(0, 0, @viewport)
@@ -183,7 +183,7 @@ class PokemonSummary_Scene
     @partyindex = partyindex
     @pokemon    = @party[@partyindex]
     @page = 4
-    @typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
+    @typebitmap = AnimatedBitmap.new("Graphics/Pictures/types")
     @sprites = {}
     @sprites["background"] = IconSprite.new(0, 0, @viewport)
     @sprites["overlay"] = BitmapSprite.new(Graphics.width, Graphics.height, @viewport)

--- a/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
+++ b/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
@@ -1444,7 +1444,7 @@ class PokemonStorageScene
       if pokemon.shiny?
         imagepos.push(["Graphics/Pictures/shiny", 156, 198])
       end
-      typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
+      typebitmap = AnimatedBitmap.new("Graphics/Pictures/types")
       pokemon.types.each_with_index do |type, i|
         type_number = GameData::Type.get(type).icon_position
         type_rect = Rect.new(0, type_number * 28, 64, 28)

--- a/Data/Scripts/016_UI/021_UI_MoveRelearner.rb
+++ b/Data/Scripts/016_UI/021_UI_MoveRelearner.rb
@@ -42,7 +42,7 @@ class MoveRelearner_Scene
     @sprites["msgwindow"] = Window_AdvancedTextPokemon.new("")
     @sprites["msgwindow"].visible = false
     @sprites["msgwindow"].viewport = @viewport
-    @typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
+    @typebitmap = AnimatedBitmap.new("Graphics/Pictures/types")
     pbDrawMoveList
     pbDeactivateWindows(@sprites)
     # Fade in all sprites

--- a/Data/Scripts/016_UI/024_UI_TextEntry.rb
+++ b/Data/Scripts/016_UI/024_UI_TextEntry.rb
@@ -484,7 +484,7 @@ class PokemonEntryScene2
     @sprites["controls"] = IconSprite.new(0, 0, @viewport)
     @sprites["controls"].x = 16
     @sprites["controls"].y = 96
-    @sprites["controls"].setBitmap(_INTL("Graphics/Pictures/Naming/overlay_controls"))
+    @sprites["controls"].setBitmap("Graphics/Pictures/Naming/overlay_controls")
     @init = true
     @sprites["overlay"] = BitmapSprite.new(Graphics.width, Graphics.height, @viewport)
     pbDoUpdateOverlay2
@@ -502,7 +502,7 @@ class PokemonEntryScene2
   def pbDoUpdateOverlay2
     overlay = @sprites["overlay"].bitmap
     overlay.clear
-    modeIcon = [[_INTL("Graphics/Pictures/Naming/icon_mode"), 44 + (@mode * 62), 120, @mode * 60, 0, 60, 44]]
+    modeIcon = [["Graphics/Pictures/Naming/icon_mode", 44 + (@mode * 62), 120, @mode * 60, 0, 60, 44]]
     pbDrawImagePositions(overlay, modeIcon)
   end
 

--- a/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
+++ b/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
@@ -89,7 +89,7 @@ class TriadCard
       cardbitmap.dispose
     end
     if type
-      typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
+      typebitmap = AnimatedBitmap.new("Graphics/Pictures/types")
       type_number = GameData::Type.get(type).icon_position
       typerect = Rect.new(0, type_number * 28, 64, 28)
       bitmap.blt(8, 50, typebitmap.bitmap, typerect, 192)
@@ -106,7 +106,7 @@ class TriadCard
     else            # Player
       cardbitmap = AnimatedBitmap.new("Graphics/Pictures/triad_card_player")
     end
-    typebitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/types"))
+    typebitmap = AnimatedBitmap.new("Graphics/Pictures/types")
     iconbitmap = AnimatedBitmap.new(GameData::Species.icon_filename(@species, @form))
     numbersbitmap = AnimatedBitmap.new("Graphics/Pictures/triad_numbers")
     # Draw card background

--- a/Data/Scripts/017_Minigames/003_Minigame_SlotMachine.rb
+++ b/Data/Scripts/017_Minigames/003_Minigame_SlotMachine.rb
@@ -32,7 +32,7 @@ class SlotMachineReel < BitmapSprite
     @stopping = false
     @slipping = 0
     @index = rand(@reel.length)
-    @images = AnimatedBitmap.new(_INTL("Graphics/Pictures/Slot Machine/images"))
+    @images = AnimatedBitmap.new("Graphics/Pictures/Slot Machine/images")
     @shading = AnimatedBitmap.new("Graphics/Pictures/Slot Machine/ReelOverlay")
     update
   end


### PR DESCRIPTION
The previous commit tackling this issue didn't remove all instances of _INTL from file paths, so this PR removes the remaining ones that I could find.