### PR TITLE
Removed all instances of SpriteWrapper

### DIFF
--- a/Data/Scripts/006_Map renderer/001_TilemapRenderer.rb
+++ b/Data/Scripts/006_Map renderer/001_TilemapRenderer.rb
@@ -30,7 +30,7 @@ class TilemapRenderer
   #     tile layouts. For example, "Brick path" and "Sea".
   #   - The second is for single tile autotiles. For example, "Flowers1" and
   #     "Waterfall"
-  # Ihe top tiles of the tileset will instead use these autotiles. Large
+  # The top tiles of the tileset will instead use these autotiles. Large
   # autotiles come first, in the same 8x6 layout as you see when you double-
   # click on a real autotile in RMXP. After that are the single tile autotiles.
   # Extra autotiles are only useful if the tiles are animated, because otherwise

--- a/Data/Scripts/007_Objects and windows/007_SpriteWrapper.rb
+++ b/Data/Scripts/007_Objects and windows/007_SpriteWrapper.rb
@@ -1,5 +1,6 @@
 #===============================================================================
 # SpriteWrapper is a class which wraps (most of) Sprite's properties.
+# (unused) Use class Sprite instead
 #===============================================================================
 class SpriteWrapper
   def initialize(viewport = nil)
@@ -93,7 +94,7 @@ end
 # Sprite class that maintains a bitmap of its own.
 # This bitmap can't be changed to a different one.
 #===============================================================================
-class BitmapSprite < SpriteWrapper
+class BitmapSprite < Sprite
   def initialize(width, height, viewport = nil)
     super(viewport)
     self.bitmap = Bitmap.new(width, height)
@@ -115,7 +116,7 @@ end
 #===============================================================================
 #
 #===============================================================================
-class AnimatedSprite < SpriteWrapper
+class AnimatedSprite < Sprite
   attr_reader :frame
   attr_reader :framewidth
   attr_reader :frameheight
@@ -241,7 +242,7 @@ end
 #===============================================================================
 # Displays an icon bitmap in a sprite. Supports animated images.
 #===============================================================================
-class IconSprite < SpriteWrapper
+class IconSprite < Sprite
   attr_reader :name
 
   def initialize(*args)
@@ -312,21 +313,9 @@ end
 
 
 #===============================================================================
-# Old GifSprite class, retained for compatibility
+# Sprite class that stores multiple bitmaps, and displays only one at once.
 #===============================================================================
-class GifSprite < IconSprite
-  def initialize(path)
-    super(0, 0)
-    setBitmap(path)
-  end
-end
-
-
-
-#===============================================================================
-# SpriteWrapper that stores multiple bitmaps, and displays only one at once.
-#===============================================================================
-class ChangelingSprite < SpriteWrapper
+class ChangelingSprite < Sprite
   def initialize(x = 0, y = 0, viewport = nil)
     super(viewport)
     self.x = x

--- a/Data/Scripts/009_Scenes/002_EventScene.rb
+++ b/Data/Scripts/009_Scenes/002_EventScene.rb
@@ -1,4 +1,4 @@
-class PictureSprite < SpriteWrapper
+class PictureSprite < Sprite
   def initialize(viewport, picture)
     super(viewport)
     @picture = picture

--- a/Data/Scripts/011_Battle/004_Scene/005_Battle_Scene_Menus.rb
+++ b/Data/Scripts/011_Battle/004_Scene/005_Battle_Scene_Menus.rb
@@ -134,7 +134,7 @@ class Battle::Scene::CommandMenu < Battle::Scene::MenuBase
       @buttonBitmap = AnimatedBitmap.new(_INTL("Graphics/Pictures/Battle/cursor_command"))
       # Create action buttons
       @buttons = Array.new(4) do |i|   # 4 command options, therefore 4 buttons
-        button = SpriteWrapper.new(viewport)
+        button = Sprite.new(viewport)
         button.bitmap = @buttonBitmap.bitmap
         button.x = self.x + Graphics.width - 260
         button.x += (i.even? ? 0 : (@buttonBitmap.width / 2) - 4)
@@ -241,7 +241,7 @@ class Battle::Scene::FightMenu < Battle::Scene::MenuBase
       addSprite("background", background)
       # Create move buttons
       @buttons = Array.new(Pokemon::MAX_MOVES) do |i|
-        button = SpriteWrapper.new(viewport)
+        button = Sprite.new(viewport)
         button.bitmap = @buttonBitmap.bitmap
         button.x = self.x + 4
         button.x += (i.even? ? 0 : (@buttonBitmap.width / 2) - 4)
@@ -265,21 +265,21 @@ class Battle::Scene::FightMenu < Battle::Scene::MenuBase
       pbSetNarrowFont(@infoOverlay.bitmap)
       addSprite("infoOverlay", @infoOverlay)
       # Create type icon
-      @typeIcon = SpriteWrapper.new(viewport)
+      @typeIcon = Sprite.new(viewport)
       @typeIcon.bitmap = @typeBitmap.bitmap
       @typeIcon.x      = self.x + 416
       @typeIcon.y      = self.y + 20
       @typeIcon.src_rect.height = TYPE_ICON_HEIGHT
       addSprite("typeIcon", @typeIcon)
       # Create Mega Evolution button
-      @megaButton = SpriteWrapper.new(viewport)
+      @megaButton = Sprite.new(viewport)
       @megaButton.bitmap = @megaEvoBitmap.bitmap
       @megaButton.x      = self.x + 120
       @megaButton.y      = self.y - (@megaEvoBitmap.height / 2)
       @megaButton.src_rect.height = @megaEvoBitmap.height / 2
       addSprite("megaButton", @megaButton)
       # Create Shift button
-      @shiftButton = SpriteWrapper.new(viewport)
+      @shiftButton = Sprite.new(viewport)
       @shiftButton.bitmap = @shiftBitmap.bitmap
       @shiftButton.x      = self.x + 4
       @shiftButton.y      = self.y - @shiftBitmap.height
@@ -481,7 +481,7 @@ class Battle::Scene::TargetMenu < Battle::Scene::MenuBase
       #       that side's trainer, so inc is different for each side for the
       #       same value of i/2.
       inc = (i.even?) ? i / 2 : numButtons - 1 - (i / 2)
-      button = SpriteWrapper.new(viewport)
+      button = Sprite.new(viewport)
       button.bitmap = @buttonBitmap.bitmap
       button.src_rect.width  = (@smallButtons) ? CMD_BUTTON_WIDTH_SMALL : @buttonBitmap.width / 2
       button.src_rect.height = BUTTON_HEIGHT

--- a/Data/Scripts/011_Battle/004_Scene/006_Battle_Scene_Objects.rb
+++ b/Data/Scripts/011_Battle/004_Scene/006_Battle_Scene_Objects.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 # Data box for regular battles
 #===============================================================================
-class Battle::Scene::PokemonDataBox < SpriteWrapper
+class Battle::Scene::PokemonDataBox < Sprite
   attr_reader   :battler
   attr_accessor :selected
   attr_reader   :animatingHP
@@ -84,12 +84,12 @@ class Battle::Scene::PokemonDataBox < SpriteWrapper
 #    pbSetSmallFont(@hpNumbers.bitmap)
     @sprites["hpNumbers"] = @hpNumbers
     # Create sprite wrapper that displays HP bar
-    @hpBar = SpriteWrapper.new(viewport)
+    @hpBar = Sprite.new(viewport)
     @hpBar.bitmap = @hpBarBitmap.bitmap
     @hpBar.src_rect.height = @hpBarBitmap.height / 3
     @sprites["hpBar"] = @hpBar
     # Create sprite wrapper that displays Exp bar
-    @expBar = SpriteWrapper.new(viewport)
+    @expBar = Sprite.new(viewport)
     @expBar.bitmap = @expBarBitmap.bitmap
     @sprites["expBar"] = @expBar
     # Create sprite wrapper that displays everything except the above
@@ -407,7 +407,7 @@ end
 #===============================================================================
 # Splash bar to announce a triggered ability
 #===============================================================================
-class Battle::Scene::AbilitySplashBar < SpriteWrapper
+class Battle::Scene::AbilitySplashBar < Sprite
   attr_reader :battler
 
   TEXT_BASE_COLOR   = Color.new(0, 0, 0)
@@ -419,7 +419,7 @@ class Battle::Scene::AbilitySplashBar < SpriteWrapper
     @battler = nil
     # Create sprite wrapper that displays background graphic
     @bgBitmap = AnimatedBitmap.new("Graphics/Pictures/Battle/ability_bar")
-    @bgSprite = SpriteWrapper.new(viewport)
+    @bgSprite = Sprite.new(viewport)
     @bgSprite.bitmap = @bgBitmap.bitmap
     @bgSprite.src_rect.y      = (side == 0) ? 0 : @bgBitmap.height / 2
     @bgSprite.src_rect.height = @bgBitmap.height / 2

--- a/Data/Scripts/011_Battle/007_Other battle types/001_SafariBattle.rb
+++ b/Data/Scripts/011_Battle/007_Other battle types/001_SafariBattle.rb
@@ -59,7 +59,7 @@ end
 #===============================================================================
 # Data box for safari battles
 #===============================================================================
-class Battle::Scene::SafariDataBox < SpriteWrapper
+class Battle::Scene::SafariDataBox < Sprite
   attr_accessor :selected
 
   def initialize(battle, viewport = nil)

--- a/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
@@ -43,7 +43,7 @@ end
 #===============================================================================
 # Visibility circle in dark maps
 #===============================================================================
-class DarknessSprite < SpriteWrapper
+class DarknessSprite < Sprite
   attr_reader :radius
 
   def initialize(viewport = nil)

--- a/Data/Scripts/013_Items/007_Item_Sprites.rb
+++ b/Data/Scripts/013_Items/007_Item_Sprites.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 # Item icon
 #===============================================================================
-class ItemIconSprite < SpriteWrapper
+class ItemIconSprite < Sprite
   attr_reader :item
 
   ANIM_ICON_SIZE   = 48
@@ -115,7 +115,7 @@ end
 #===============================================================================
 # Item held icon (used in the party screen)
 #===============================================================================
-class HeldItemIconSprite < SpriteWrapper
+class HeldItemIconSprite < Sprite
   def initialize(x, y, pokemon, viewport = nil)
     super(viewport)
     self.x = x

--- a/Data/Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 # Pokémon sprite (used out of battle)
 #===============================================================================
-class PokemonSprite < SpriteWrapper
+class PokemonSprite < Sprite
   def initialize(viewport = nil)
     super(viewport)
     @_iconbitmap = nil
@@ -82,7 +82,7 @@ end
 #===============================================================================
 # Pokémon icon (for defined Pokémon)
 #===============================================================================
-class PokemonIconSprite < SpriteWrapper
+class PokemonIconSprite < Sprite
   attr_accessor :selected
   attr_accessor :active
   attr_reader   :pokemon
@@ -217,7 +217,7 @@ end
 #===============================================================================
 # Pokémon icon (for species)
 #===============================================================================
-class PokemonSpeciesIconSprite < SpriteWrapper
+class PokemonSpeciesIconSprite < Sprite
   attr_reader :species
   attr_reader :gender
   attr_reader :form

--- a/Data/Scripts/015_Trainers and player/003_Trainer_Sprites.rb
+++ b/Data/Scripts/015_Trainers and player/003_Trainer_Sprites.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 # Walking charset, for use in text entry screens and load game screen
 #===============================================================================
-class TrainerWalkingCharSprite < SpriteWrapper
+class TrainerWalkingCharSprite < Sprite
   def initialize(charset, viewport = nil)
     super(viewport)
     @animbitmap = nil

--- a/Data/Scripts/016_UI/001_Non-interactive UI/003_UI_EggHatching.rb
+++ b/Data/Scripts/016_UI/001_Non-interactive UI/003_UI_EggHatching.rb
@@ -33,7 +33,7 @@ class PokemonEggHatch_Scene
     crackfilename = pbResolveBitmap(crackfilename)
     @hatchSheet = AnimatedBitmap.new(crackfilename)
     # Create egg cracks sprite
-    @sprites["hatch"] = SpriteWrapper.new(@viewport)
+    @sprites["hatch"] = Sprite.new(@viewport)
     @sprites["hatch"].x = @sprites["pokemon"].x
     @sprites["hatch"].y = @sprites["pokemon"].y
     @sprites["hatch"].ox = @sprites["pokemon"].ox

--- a/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
+++ b/Data/Scripts/016_UI/003_UI_Pokedex_Main.rb
@@ -75,7 +75,7 @@ end
 #===============================================================================
 #
 #===============================================================================
-class PokedexSearchSelectionSprite < SpriteWrapper
+class PokedexSearchSelectionSprite < Sprite
   attr_reader :index
   attr_accessor :cmds
   attr_accessor :minmax

--- a/Data/Scripts/016_UI/005_UI_Party.rb
+++ b/Data/Scripts/016_UI/005_UI_Party.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 # Pokémon party buttons and menu
 #===============================================================================
-class PokemonPartyConfirmCancelSprite < SpriteWrapper
+class PokemonPartyConfirmCancelSprite < Sprite
   attr_reader :selected
 
   def initialize(text, x, y, narrowbox = false, viewport = nil)
@@ -133,7 +133,7 @@ end
 #===============================================================================
 # Blank party panel
 #===============================================================================
-class PokemonPartyBlankPanel < SpriteWrapper
+class PokemonPartyBlankPanel < Sprite
   attr_accessor :text
 
   def initialize(_pokemon, index, viewport = nil)
@@ -162,7 +162,7 @@ end
 #===============================================================================
 # Pokémon party panel
 #===============================================================================
-class PokemonPartyPanel < SpriteWrapper
+class PokemonPartyPanel < Sprite
   attr_reader :pokemon
   attr_reader :active
   attr_reader :selected

--- a/Data/Scripts/016_UI/006_UI_Summary.rb
+++ b/Data/Scripts/016_UI/006_UI_Summary.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 #
 #===============================================================================
-class MoveSelectionSprite < SpriteWrapper
+class MoveSelectionSprite < Sprite
   attr_reader :preselected
   attr_reader :index
 

--- a/Data/Scripts/016_UI/008_UI_Pokegear.rb
+++ b/Data/Scripts/016_UI/008_UI_Pokegear.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 #
 #===============================================================================
-class PokegearButton < SpriteWrapper
+class PokegearButton < Sprite
   attr_reader :index
   attr_reader :name
   attr_reader :selected

--- a/Data/Scripts/016_UI/009_UI_RegionMap.rb
+++ b/Data/Scripts/016_UI/009_UI_RegionMap.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 #
 #===============================================================================
-class MapBottomSprite < SpriteWrapper
+class MapBottomSprite < Sprite
   attr_reader :mapname, :maplocation
 
   TEXT_MAIN_COLOR   = Color.new(248, 248, 248)

--- a/Data/Scripts/016_UI/013_UI_Load.rb
+++ b/Data/Scripts/016_UI/013_UI_Load.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 #
 #===============================================================================
-class PokemonLoadPanel < SpriteWrapper
+class PokemonLoadPanel < Sprite
   attr_reader :selected
 
   TEXTCOLOR             = Color.new(232, 232, 232)

--- a/Data/Scripts/016_UI/016_UI_ReadyMenu.rb
+++ b/Data/Scripts/016_UI/016_UI_ReadyMenu.rb
@@ -1,7 +1,7 @@
 #===============================================================================
 #
 #===============================================================================
-class ReadyMenuButton < SpriteWrapper
+class ReadyMenuButton < Sprite
   attr_reader :index   # ID of button
   attr_reader :selected
   attr_reader :side

--- a/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
+++ b/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
@@ -117,7 +117,7 @@ end
 #===============================================================================
 # Cursor
 #===============================================================================
-class PokemonBoxArrow < SpriteWrapper
+class PokemonBoxArrow < Sprite
   attr_accessor :quickswap
 
   def initialize(viewport = nil)
@@ -288,7 +288,7 @@ end
 #===============================================================================
 # Box
 #===============================================================================
-class PokemonBoxSprite < SpriteWrapper
+class PokemonBoxSprite < Sprite
   attr_accessor :refreshBox
   attr_accessor :refreshSprites
 
@@ -443,7 +443,7 @@ end
 #===============================================================================
 # Party pop-up panel
 #===============================================================================
-class PokemonBoxPartySprite < SpriteWrapper
+class PokemonBoxPartySprite < Sprite
   def initialize(party, viewport = nil)
     super(viewport)
     @party = party

--- a/Data/Scripts/016_UI/022_UI_PurifyChamber.rb
+++ b/Data/Scripts/016_UI/022_UI_PurifyChamber.rb
@@ -843,7 +843,7 @@ end
 #===============================================================================
 #
 #===============================================================================
-class PurifyChamberSetView < SpriteWrapper
+class PurifyChamberSetView < Sprite
   attr_reader :set
   attr_reader :cursor
   attr_reader :heldpkmn

--- a/Data/Scripts/016_UI/024_UI_TextEntry.rb
+++ b/Data/Scripts/016_UI/024_UI_TextEntry.rb
@@ -279,7 +279,7 @@ class PokemonEntryScene2
 
   class NameEntryCursor
     def initialize(viewport)
-      @sprite = SpriteWrapper.new(viewport)
+      @sprite = Sprite.new(viewport)
       @cursortype = 0
       @cursor1 = AnimatedBitmap.new("Graphics/Pictures/Naming/cursor_1")
       @cursor2 = AnimatedBitmap.new("Graphics/Pictures/Naming/cursor_2")
@@ -468,16 +468,16 @@ class PokemonEntryScene2
     @minlength = minlength
     @maxlength = maxlength
     @maxlength.times { |i|
-      @sprites["blank#{i}"] = SpriteWrapper.new(@viewport)
+      @sprites["blank#{i}"] = Sprite.new(@viewport)
       @sprites["blank#{i}"].x = 160 + (24 * i)
       @sprites["blank#{i}"].bitmap = @bitmaps[@bitmaps.length - 1]
       @blanks[i] = 0
     }
-    @sprites["bottomtab"] = SpriteWrapper.new(@viewport)   # Current tab
+    @sprites["bottomtab"] = Sprite.new(@viewport)   # Current tab
     @sprites["bottomtab"].x = 22
     @sprites["bottomtab"].y = 162
     @sprites["bottomtab"].bitmap = @bitmaps[@@Characters.length]
-    @sprites["toptab"] = SpriteWrapper.new(@viewport)   # Next tab
+    @sprites["toptab"] = Sprite.new(@viewport)   # Next tab
     @sprites["toptab"].x = 22 - 504
     @sprites["toptab"].y = 162
     @sprites["toptab"].bitmap = @bitmaps[@@Characters.length + 1]

--- a/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
+++ b/Data/Scripts/017_Minigames/002_Minigame_TripleTriad.rb
@@ -173,7 +173,7 @@ class TriadScene
       "", 0, Graphics.height - 64, Graphics.width, 64, @viewport
     )
     (@battle.width * @battle.height).times do |i|
-      @sprites["sprite#{i}"] = SpriteWrapper.new(@viewport)
+      @sprites["sprite#{i}"] = Sprite.new(@viewport)
       @sprites["sprite#{i}"].x = (Graphics.width / 2) - 118 + ((i % 3) * 78)
       @sprites["sprite#{i}"].y = 36 + ((i / 3) * 94)
       @sprites["sprite#{i}"].z = 2

--- a/Data/Scripts/020_Debug/002_Animation editor/001_AnimEditor_SceneElements.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/001_AnimEditor_SceneElements.rb
@@ -163,7 +163,7 @@ end
 ################################################################################
 # Sprite sheet scrolling bar
 ################################################################################
-class AnimationWindow < SpriteWrapper
+class AnimationWindow < Sprite
   attr_reader :animbitmap
   attr_reader :start
   attr_reader :selected

--- a/Data/Scripts/020_Debug/002_Animation editor/003_AnimEditor_Interpolation.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/003_AnimEditor_Interpolation.rb
@@ -1,7 +1,7 @@
 ################################################################################
 # Paths and interpolation
 ################################################################################
-class ControlPointSprite < SpriteWrapper
+class ControlPointSprite < Sprite
   attr_accessor :dragging
 
   def initialize(red, viewport = nil)
@@ -50,7 +50,7 @@ end
 
 
 
-class PointSprite < SpriteWrapper
+class PointSprite < Sprite
   def initialize(x, y, viewport = nil)
     super(viewport)
     self.bitmap = Bitmap.new(2, 2)

--- a/Data/Scripts/020_Debug/003_Editor_Listers.rb
+++ b/Data/Scripts/020_Debug/003_Editor_Listers.rb
@@ -305,7 +305,7 @@ end
 #===============================================================================
 class MapLister
   def initialize(selmap, addGlobal = false)
-    @sprite = SpriteWrapper.new
+    @sprite = Sprite.new
     @sprite.bitmap = nil
     @sprite.x      = Graphics.width * 3 / 4
     @sprite.y      = ((Graphics.height - 64) / 2) + 64


### PR DESCRIPTION
The sole purpose of its existence (i.e. allowing sprites to switch viewports easily) is already handled by the Sprite class in MKXP. This PR aims to remove all instances of the deprecated class from base Essentials.