### PR TITLE
Fixed movement type in some methods

### DIFF
--- a/Data/Scripts/004_Game classes/009_Game_Player.rb
+++ b/Data/Scripts/004_Game classes/009_Game_Player.rb
@@ -574,13 +574,13 @@ end
 
 def pbUpdateVehicle
   if $PokemonGlobal&.diving
-    $game_player.set_movement_type(:diving)
+    $game_player.set_movement_type(:diving_stopped)
   elsif $PokemonGlobal&.surfing
-    $game_player.set_movement_type(:surfing)
+    $game_player.set_movement_type(:surfing_stopped)
   elsif $PokemonGlobal&.bicycle
-    $game_player.set_movement_type(:cycling)
+    $game_player.set_movement_type(:cycling_stopped)
   else
-    $game_player.set_movement_type(:walking)
+    $game_player.set_movement_type(:walking_stopped)
   end
 end
 

--- a/Data/Scripts/012_Overworld/005_Overworld_Fishing.rb
+++ b/Data/Scripts/012_Overworld/005_Overworld_Fishing.rb
@@ -29,7 +29,7 @@ def pbFishingEnd
     end
   end
   yield if block_given?
-  $game_player.set_movement_type(($PokemonGlobal.surfing) ? :surfing : :walking)
+  $game_player.set_movement_type(($PokemonGlobal.surfing) ? :surfing_stopped : :walking_stopped)
   $game_player.lock_pattern = false
   $game_player.straighten
   $PokemonGlobal.fishing = false


### PR DESCRIPTION
Updated the movement type set by `pbUpdateVehicle` and `pbFishingEnd` to use the `_stopped` version of the movement types. This allows plugins that implement separate "Stationary" charsets to work properly.