### PR TITLE
Edited string methods

### DIFF
--- a/Data/Scripts/001_Technical/002_RubyUtilities.rb
+++ b/Data/Scripts/001_Technical/002_RubyUtilities.rb
@@ -23,7 +23,7 @@ end
 #===============================================================================
 class String
   def starts_with_vowel?
-    return ["a", "e", "i", "o", "u"].include?(self[0, 1].downcase)
+    return ["a", "e", "i", "o", "u"].include?(self[0].downcase)
   end
 
   def first(n = 1); return self[0...n]; end

--- a/Data/Scripts/001_Technical/002_RubyUtilities.rb
+++ b/Data/Scripts/001_Technical/002_RubyUtilities.rb
@@ -52,7 +52,7 @@ class String
   end
 
   def numeric?
-    return !self[/^[+-]?([0-9]+)(?:\.[0-9]+)?$/].nil?
+    return !self[/\A[+-]?\d+(?:\.\d+)?\Z/].nil?
   end
 end
 


### PR DESCRIPTION
- `^` may match the position right after a newline character, and `$` may match right before the newline character (due to the multiline flag being enabled by default), so substing these with `\A` and `\Z`.
- Substed both instances of `[0-9]` with the shorthand `\d`.
- Removed capturing group around the first `\d+`.