### PR TITLE
Fixed line break not working on lose_text/win_text

### DIFF
--- a/Data/Scripts/011_Battle/001_Battle/002_Battle_StartAndEnd.rb
+++ b/Data/Scripts/011_Battle/001_Battle/002_Battle_StartAndEnd.rb
@@ -424,7 +424,7 @@ class Battle
           @scene.pbShowOpponent(i)
           msg = trainer.lose_text
           msg = "..." if !msg || msg.empty?
-          pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name))
+          pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name).gsub(/\\[Nn]/, "\n"))
         end
       end
       # Gain money from winning a trainer battle, and from Pay Day
@@ -459,7 +459,7 @@ class Battle
             @scene.pbShowOpponent(i)
             msg = trainer.win_text
             msg = "..." if !msg || msg.empty?
-            pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name))
+            pbDisplayPaused(msg.gsub(/\\[Pp][Nn]/, pbPlayer.name).gsub(/\\[Nn]/, "\n"))
           end
         end
       end


### PR DESCRIPTION
This issue starts happening on v18, when lose_text goes to trainers PBS.

This PR fix win_text as well.