### PR TITLE
Remove powder check from Magic Powder

### DIFF
--- a/Data/Scripts/011_Battle/003_Move/007_MoveEffects_BattlerOther.rb
+++ b/Data/Scripts/011_Battle/003_Move/007_MoveEffects_BattlerOther.rb
@@ -844,7 +844,7 @@ class Battle::Move::SetTargetTypesToPsychic < Battle::Move
 
   def pbFailsAgainstTarget?(user, target, show_message)
     if !target.canChangeType? || !GameData::Type.exists?(:PSYCHIC) ||
-       !target.pbHasOtherType?(:PSYCHIC) || !target.affectedByPowder?
+       !target.pbHasOtherType?(:PSYCHIC)
       @battle.pbDisplay(_INTL("But it failed!")) if show_message
       return true
     end


### PR DESCRIPTION
This is already handled by the `Powder` flag on Magic Powder, so this is unneeded.