### PR TITLE
Fix LocationWindow being visible before Fly transitions finish

### DIFF
--- a/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld visuals/002_Overworld_Overlays.rb
@@ -9,7 +9,7 @@ class LocationWindow
     @window = Window_AdvancedTextPokemon.new(name)
     @window.resizeToFit(name, Graphics.width)
     @window.x        = 0
-    @window.y        = -@window.height
+    @window.y        = -@window.height - 4
     @window.viewport = Viewport.new(0, 0, Graphics.width, Graphics.height)
     @window.viewport.z = 99999
     @currentmap = $game_map.map_id


### PR DESCRIPTION
The LocationWindow textbox is supposed to slide in from the top left of the screen when entering a new map, but it is initialized with a small part of it just barely visible on-screen, rather than fully above the screen. This means you can see it stationary in the corner when the Fly transition is being played. This PR moves it up slightly to avoid that.