### PR TITLE
Fixed bug where follower sprites did not update correctly after exiting the terrain tag editor

### DIFF
--- a/Data/Scripts/020_Debug/001_Editor screens/002_EditorScreens_TerrainTags.rb
+++ b/Data/Scripts/020_Debug/001_Editor screens/002_EditorScreens_TerrainTags.rb
@@ -46,6 +46,8 @@ class PokemonTilesetScene
       $game_player.center($game_player.x, $game_player.y)
       if $scene.is_a?(Scene_Map)
         $scene.dispose
+        # Reset map objects in each follower event
+        $game_temp.followers = Game_FollowerFactory.new
         $scene.createSpritesets
       end
     end


### PR DESCRIPTION
This PR fixes the bug mentioned in the title. The issue is that if the player has a follower with them, then enters and exits the terrain tag editor from the Debug menu (even without making any edits), the follower sprite would start to move weirdly until the next map transfer (attached a gif below to demonstrate the issue).
![weird_glitch](https://github.com/Maruno17/pokemon-essentials/assets/14132548/0b7e6cc2-8527-4447-b5ee-31bb21bb8da2)
The root cause of this issue is that after exiting the terrain tag editor, the game reloads all of the spritesets, including the current map. The follower sprites have an internal attribute `@map` that points to the current map object, but when the spritesets get reloaded, the current map object changes, so the follower sprites are still pointing to the old map object. This messes up the calculations used for the follower sprites' display coordinates as it relies on the old map's display coordinates instead of the new one.
This PR fixes this issue by simply refreshing the follower factory in between disposing the old spritesets and creating the new ones after exiting the terrain tag editor.