### PR TITLE
Fixed storage hand issue when activating quick swap mode while holding a pokémon

### DIFF
--- a/Data/Scripts/016b_UI redesign/017_UI_PokemonStorage.rb
+++ b/Data/Scripts/016b_UI redesign/017_UI_PokemonStorage.rb
@@ -611,7 +611,7 @@ class UI::PokemonStorageVisualsCursor < UI::SpriteContainer
   def quick_swap_mode=(value)
     return if @quick_swap_mode == value
     @quick_swap_mode = value
-    refresh_cursor
+    @sprites[:cursor].change_bitmap((@quick_swap_mode) ? :fistq : :fist) if holding_pokemon?
   end
 
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
The issue, before the fix:
<img width="217" height="162" alt="2025-08-24 08_45_24-Pokémon Essentials v21 1" src="https://github.com/user-attachments/assets/3369d034-ac46-4307-98bf-4e6317175c67" />

I removed one 'refresh' call since it is called in the update when the hand isn't holding anything.