### PR TITLE
Fix BGS not fading out when autoplay_bgs is set

### DIFF
--- a/Data/Scripts/003_Game processing/002_Scene_Map.rb
+++ b/Data/Scripts/003_Game processing/002_Scene_Map.rb
@@ -62,7 +62,7 @@ class Scene_Map
       pbBGMFade(0.8) if playingBGM.name != test_filename
     end
     if playingBGS && map.autoplay_bgs && playingBGS.name != map.bgs.name
-      pbBGMFade(0.8)
+      pbBGSFade(0.8)
     end
     Graphics.frame_reset
   end


### PR DESCRIPTION
Currently, BGS does not fade out if set to autoplay and blank/none, and will keep playing. This change fixes that behavior.